### PR TITLE
WIP: adding functionality to only request changes in full-history extraction

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1064,7 +1064,7 @@ Extraction Endpoints
    Get the state of OSM data at the given timestamp(s) as a GeoJSON feature collection where object geometries are returned as the given ``geometryType`` (geometry, bbox, or centroid).
 
    :query time: required; format same as described in time_
-   :query properties: specifies what properties should be included for each feature representing an OSM element: ‘tags’ and/or 'metadata’; multiple values can be delimited by commas; default: empty
+   :query properties: list of possible property groups added to each OSM element ('tags' and/or 'metadata'); giving unclipped features (and/or 'unclipped'); default: empty
    :query <other>: see above_ (except **format**)
 
 .. note:: The extraction endpoints always return a .geojson file.
@@ -1132,7 +1132,8 @@ Extraction Endpoints
    This endpoint supports the same ``geometryType`` options as the ``/elements`` endpoint.
 
    :query time: required; must consist of two ISO-8601 conform timestrings defining a time interval; no default value
-   :query properties: specifies what properties should be included for each feature representing an OSM element: ‘tags’ and/or 'metadata’; multiple values can be delimited by commas; default: empty
+   :query properties: list of possible property groups added to each OSM element ('tags' and/or 'metadata'); giving unclipped features (and/or 'unclipped');
+    giving only data modifications for full history request (and/or 'modifications'); default: empty
    :query <other>: see above_ (except **format**)
 
 .. _above: endpoints.html#post--elements-(aggregation)

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -17,7 +17,7 @@ public class ParameterDescriptions {
           + "(one boundary parameter must be defined)";
   public static final String TYPES =
       "OSM type(s) 'node' and/or 'way' and/or 'relation' OR simple feature type(s) 'point' and/or "
-      + "'line' and/or 'polygon'; default: all three OSM types";
+          + "'line' and/or 'polygon'; default: all three OSM types";
   public static final String KEYS = "OSM key(s) e.g.: 'highway', 'building'; default: no key";
   public static final String GROUP_BY_KEY = "OSM key e.g.: 'highway', 'building'; no default "
       + "value (one groupByKey parameter must be defined)";
@@ -27,14 +27,14 @@ public class ParameterDescriptions {
       "ISO-8601 conform timestring(s); default: latest timestamp within dataset";
   public static final String TIME_DATA_EXTRACTION =
       "ISO-8601 conform timestring(s) defining timestamps (/elements), "
-      + "or intervals (/elementsFullHistory); no default value";
+          + "or intervals (/elementsFullHistory); no default value";
   public static final String FORMAT =
       "Output format geojson (for /groupBy/boundary resources only), csv, or json; default: json";
   public static final String PROPERTIES =
-      "List of possible property-groups added to each OSM-element: 'tags' and/or 'metadata'; "
-          + "default: no property";
-  public static final String SHOW_METADATA =
-      "Boolean operator 'true' or 'false'; default: 'false'";
+      "List of possible property groups added to each OSM element ('tags' and/or 'metadata');"
+          + "Giving unclipped features (and/or 'unclipped'); Giving only data modifications "
+          + "for full history request (and/or 'modifications'); default: no property";
+  public static final String SHOW_METADATA = "Boolean operator 'true' or 'false'; default: 'false'";
   public static final String TIMEOUT = "Custom timeout in seconds;";
   public static final String FILTER = "Combines several attributive filters, e.g. OSM type, "
       + "the geometry (simple feature) type, as well as the OSM tag; no default value";

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -91,7 +91,7 @@ public class ElementsRequestExecutor {
    *         {@link org.heigit.ohsome.ohsomeapi.inputprocessing.InputProcessor#processParameters()
    *         processParameters},
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer#stream() stream}, or
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#streamElementsResponse(HttpServletResponse, DataResponse, boolean, Stream, Stream)
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#streamElementsResponse(HttpServletResponse, DataResponse, Stream)
    *         streamElementsResponse}
    */
   public static void extract(ElementsGeometry elemGeom, HttpServletRequest servletRequest,
@@ -165,7 +165,7 @@ public class ElementsRequestExecutor {
    *         {@link org.heigit.bigspatialdata.oshdb.util.time.ISODateTimeParser#parseISODateTime(String)
    *         parseISODateTime},
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer#stream() stream}, or
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#streamElementsResponse(HttpServletResponse, DataResponse, boolean, Stream, Stream)
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#streamElementsResponse(HttpServletResponse, DataResponse, Stream)
    *         streamElementsResponse}
    */
   public static void extractFullHistory(ElementsGeometry elemGeom,

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -208,7 +208,7 @@ public class ElementsRequestExecutor {
     final boolean includeTags = inputProcessor.includeTags();
     final boolean includeOSMMetadata = inputProcessor.includeOSMMetadata();
     final boolean unclippedGeometries = inputProcessor.isUnclipped();
-    final boolean onlyModifications = inputProcessor.modifications();
+    final boolean modificationsOnly = inputProcessor.isModificationsOnly();
     final Set<SimpleFeatureType> simpleFeatureTypes = processingData.getSimpleFeatureTypes();
     Optional<FilterExpression> filter = processingData.getFilterExpression();
     final boolean requiresGeometryTypeCheck =
@@ -307,52 +307,48 @@ public class ElementsRequestExecutor {
     }
     DataResponse osmData = new DataResponse(new Attribution(URL, TEXT), Application.API_VERSION,
         metadata, "FeatureCollection", Collections.emptyList());
-    MapReducer<Feature> snapshotPreResult = null;
-    if (!onlyModifications) {
+    Stream<Feature> contributionStream = contributionPreResult.stream();
+    Stream<Feature> snapshotStream = null;
+    if (!modificationsOnly) {
       // handles cases where valid_from = t_start, valid_to = t_end; i.e. non-modified data
-      snapshotPreResult = mapRedSnapshot.groupByEntity().filter(snapshots -> snapshots.size() == 2)
-          .filter(snapshots -> snapshots.get(0).getGeometry() == snapshots.get(1).getGeometry()
-              && snapshots.get(0).getEntity().getVersion() == snapshots.get(1).getEntity()
-                  .getVersion())
-          .map(snapshots -> snapshots.get(0)).flatMap(snapshot -> {
-            Map<String, Object> properties = new TreeMap<>();
-            OSMEntity entity = snapshot.getEntity();
-            if (includeOSMMetadata) {
-              properties.put("@lastEdit", entity.getTimestamp().toString());
-            }
-            Geometry geom = snapshot.getGeometry();
-            if (unclippedGeometries) {
-              geom = snapshot.getGeometryUnclipped();
-            }
-            properties.put("@snapshotTimestamp",
-                TimestampFormatter.getInstance().isoDateTime(snapshot.getTimestamp()));
-            properties.put("@validFrom", startTimestamp);
-            properties.put("@validTo", endTimestamp);
-            boolean addToOutput;
-            if (processingData.containsSimpleFeatureTypes()) {
-              addToOutput = utils.checkGeometryOnSimpleFeatures(geom, simpleFeatureTypes);
-            } else if (requiresGeometryTypeCheck) {
-              addToOutput = filterExpression.applyOSMGeometry(entity, geom);
-            } else {
-              addToOutput = true;
-            }
-            if (addToOutput) {
-              return Collections.singletonList(exeUtils.createOSMFeature(entity, geom, properties,
-                  keysInt, includeTags, includeOSMMetadata, elemGeom));
-            } else {
-              return Collections.emptyList();
-            }
-          }).filter(Objects::nonNull);
-      try (Stream<Feature> contributionStream = contributionPreResult.stream();
-          Stream<Feature> snapshotStream = snapshotPreResult.stream()) {
-        exeUtils.streamElementsResponse(servletResponse, osmData, true, snapshotStream,
-            contributionStream);
-      }
+      MapReducer<Feature> snapshotPreResult =
+          mapRedSnapshot.groupByEntity().filter(snapshots -> snapshots.size() == 2)
+              .filter(snapshots -> snapshots.get(0).getGeometry() == snapshots.get(1).getGeometry()
+                  && snapshots.get(0).getEntity().getVersion() == snapshots.get(1).getEntity()
+                      .getVersion())
+              .map(snapshots -> snapshots.get(0)).flatMap(snapshot -> {
+                Map<String, Object> properties = new TreeMap<>();
+                OSMEntity entity = snapshot.getEntity();
+                if (includeOSMMetadata) {
+                  properties.put("@lastEdit", entity.getTimestamp().toString());
+                }
+                Geometry geom = snapshot.getGeometry();
+                if (unclippedGeometries) {
+                  geom = snapshot.getGeometryUnclipped();
+                }
+                properties.put("@snapshotTimestamp",
+                    TimestampFormatter.getInstance().isoDateTime(snapshot.getTimestamp()));
+                properties.put("@validFrom", startTimestamp);
+                properties.put("@validTo", endTimestamp);
+                boolean addToOutput;
+                if (processingData.containsSimpleFeatureTypes()) {
+                  addToOutput = utils.checkGeometryOnSimpleFeatures(geom, simpleFeatureTypes);
+                } else if (requiresGeometryTypeCheck) {
+                  addToOutput = filterExpression.applyOSMGeometry(entity, geom);
+                } else {
+                  addToOutput = true;
+                }
+                if (addToOutput) {
+                  return Collections.singletonList(exeUtils.createOSMFeature(entity, geom,
+                      properties, keysInt, includeTags, includeOSMMetadata, elemGeom));
+                } else {
+                  return Collections.emptyList();
+                }
+              }).filter(Objects::nonNull);
+      snapshotStream = snapshotPreResult.stream();
     } else {
-      try (Stream<Feature> contributionStream = contributionPreResult.stream()) {
-        exeUtils.streamElementsResponse(servletResponse, osmData, true, null,
-            contributionStream);
-      }
+      exeUtils.streamElementsResponse(servletResponse, osmData, true, snapshotStream,
+          contributionStream);
     }
   }
 

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -239,8 +239,7 @@ public class ExecutionUtils {
 
   /** Streams the result of /elements and /elementsFullHistory respones as an outputstream. */
   public void streamElementsResponse(HttpServletResponse servletResponse, DataResponse osmData,
-      boolean isFullHistory, Stream<org.wololo.geojson.Feature> snapshotStream,
-      Stream<org.wololo.geojson.Feature> contributionStream) throws Exception {
+      Stream<org.wololo.geojson.Feature> resultStream) throws Exception {
     JsonFactory jsonFactory = new JsonFactory();
     ByteArrayOutputStream tempStream = new ByteArrayOutputStream();
 
@@ -275,12 +274,7 @@ public class ExecutionUtils {
       }
     });
     isFirst = new AtomicReference<>(true);
-    if (isFullHistory) {
-      writeStreamResponse(outputJsonGen, contributionStream, outputBuffers, outputStream);
-    }
-    if (snapshotStream != null) {
-      writeStreamResponse(outputJsonGen, snapshotStream, outputBuffers, outputStream);
-    }
+    writeStreamResponse(outputJsonGen, resultStream, outputBuffers, outputStream);
     outputStream.print("]\n}\n");
     servletResponse.flushBuffer();
   }

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -278,7 +278,9 @@ public class ExecutionUtils {
     if (isFullHistory) {
       writeStreamResponse(outputJsonGen, contributionStream, outputBuffers, outputStream);
     }
-    writeStreamResponse(outputJsonGen, snapshotStream, outputBuffers, outputStream);
+    if (snapshotStream != null) {
+      writeStreamResponse(outputJsonGen, snapshotStream, outputBuffers, outputStream);
+    }
     outputStream.print("]\n}\n");
     servletResponse.flushBuffer();
   }

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -77,6 +77,7 @@ public class InputProcessor {
   private boolean includeTags;
   private boolean includeOSMMetadata;
   private boolean unclipped;
+  private boolean modifications;
 
   public InputProcessor(HttpServletRequest servletRequest, boolean isSnapshot, boolean isDensity) {
     if (DbConnData.db instanceof OSHDBIgnite) {
@@ -473,6 +474,8 @@ public class InputProcessor {
         this.includeOSMMetadata = true;
       } else if ("unclipped".equalsIgnoreCase(property)) {
         this.unclipped = true;
+      } else if ("modifications".equalsIgnoreCase(property)) {
+        this.modifications = true;
       } else {
         throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
       }
@@ -866,5 +869,9 @@ public class InputProcessor {
 
   public boolean isUnclipped() {
     return unclipped;
+  }
+  
+  public boolean modifications() {
+    return modifications;
   }
 }

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -77,7 +77,7 @@ public class InputProcessor {
   private boolean includeTags;
   private boolean includeOSMMetadata;
   private boolean unclipped;
-  private boolean modifications;
+  private boolean modificationsOnly;
 
   public InputProcessor(HttpServletRequest servletRequest, boolean isSnapshot, boolean isDensity) {
     if (DbConnData.db instanceof OSHDBIgnite) {
@@ -475,7 +475,7 @@ public class InputProcessor {
       } else if ("unclipped".equalsIgnoreCase(property)) {
         this.unclipped = true;
       } else if ("modifications".equalsIgnoreCase(property)) {
-        this.modifications = true;
+        this.modificationsOnly = true;
       } else {
         throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
       }
@@ -871,7 +871,7 @@ public class InputProcessor {
     return unclipped;
   }
   
-  public boolean modifications() {
-    return modifications;
+  public boolean isModificationsOnly() {
+    return modificationsOnly;
   }
 }


### PR DESCRIPTION
adding 'modifications' as a value to the properties parameter
gives the full-history data without the unmodified features for the requested timespan