### PR TITLE
Adapting ratio endpoint processing

### DIFF
--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -1056,7 +1056,7 @@ public class ElementsRequestExecutor {
     ProcessingData processingData = inputProcessor.getProcessingData();
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     String filter1 = inputProcessor.getProcessingData().getRequestParameters().getFilter();
-    String filter2 = servletRequest.getParameter("filter2");
+    String filter2 = inputProcessor.createEmptyStringIfNull(servletRequest.getParameter("filter2"));
     String combinedFilter = exeUtils.combineFiltersWithOr(filter1, filter2);
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);
     FilterExpression filterExpr1 = inputProcessor.getUtils().parseFilter(fp, filter1);
@@ -1367,7 +1367,7 @@ public class ElementsRequestExecutor {
     }
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     String filter1 = inputProcessor.getProcessingData().getRequestParameters().getFilter();
-    String filter2 = servletRequest.getParameter("filter2");
+    String filter2 = inputProcessor.createEmptyStringIfNull(servletRequest.getParameter("filter2"));
     String combinedFilter = exeUtils.combineFiltersWithOr(filter1, filter2);
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);
     FilterExpression filterExpr1 = inputProcessor.getUtils().parseFilter(fp, filter1);

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -875,6 +875,8 @@ public class ElementsRequestExecutor {
   /**
    * Performs a count|length|perimeter|area|ratio calculation.
    * 
+   * @deprecated Will be removed in next major version update.
+   * 
    * @param requestResource
    *        {@link org.heigit.ohsome.ohsomeapi.executor.RequestResource
    *        RequestResource} definition of the request resource
@@ -1132,6 +1134,8 @@ public class ElementsRequestExecutor {
 
   /**
    * Performs a count|length|perimeter|area-ratio calculation grouped by the boundary.
+   * 
+   * @deprecated Will be removed in next major version update.
    * 
    * @param requestResource
    *        {@link org.heigit.ohsome.ohsomeapi.executor.RequestResource

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -1043,7 +1043,9 @@ public class ElementsRequestExecutor {
    */
   public static Response aggregateRatio(RequestResource requestResource,
       HttpServletRequest servletRequest, HttpServletResponse servletResponse) throws Exception {
-    if (null == servletRequest.getParameter("filter")) {
+    if (null == servletRequest.getParameter("filter")
+        && (null != servletRequest.getParameter("types")
+            || null != servletRequest.getParameter("keys"))) {
       return aggregateBasicFiltersRatio(requestResource, servletRequest, servletResponse);
     }
     final long startTime = System.currentTimeMillis();
@@ -1056,6 +1058,7 @@ public class ElementsRequestExecutor {
     ProcessingData processingData = inputProcessor.getProcessingData();
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     String filter1 = inputProcessor.getProcessingData().getRequestParameters().getFilter();
+    inputProcessor.checkFilter(filter1);
     String filter2 = inputProcessor.createEmptyStringIfNull(servletRequest.getParameter("filter2"));
     String combinedFilter = exeUtils.combineFiltersWithOr(filter1, filter2);
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);
@@ -1349,7 +1352,9 @@ public class ElementsRequestExecutor {
   public static <P extends Geometry & Polygonal> Response aggregateRatioGroupByBoundary(
       RequestResource requestResource, HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
-    if (null == servletRequest.getParameter("filter")) {
+    if (null == servletRequest.getParameter("filter")
+        && (null != servletRequest.getParameter("types")
+            || null != servletRequest.getParameter("keys"))) {
       return aggregateBasicFiltersRatioGroupByBoundary(requestResource, servletRequest,
           servletResponse);
     }
@@ -1367,6 +1372,7 @@ public class ElementsRequestExecutor {
     }
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     String filter1 = inputProcessor.getProcessingData().getRequestParameters().getFilter();
+    inputProcessor.checkFilter(filter1);
     String filter2 = inputProcessor.createEmptyStringIfNull(servletRequest.getParameter("filter2"));
     String combinedFilter = exeUtils.combineFiltersWithOr(filter1, filter2);
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -1060,8 +1060,8 @@ public class ElementsRequestExecutor {
     ProcessingData processingData = inputProcessor.getProcessingData();
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     String filter1 = inputProcessor.getProcessingData().getRequestParameters().getFilter();
-    inputProcessor.checkFilter(filter1);
     String filter2 = inputProcessor.createEmptyStringIfNull(servletRequest.getParameter("filter2"));
+    inputProcessor.checkFilter(filter2);
     String combinedFilter = exeUtils.combineFiltersWithOr(filter1, filter2);
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);
     FilterExpression filterExpr1 = inputProcessor.getUtils().parseFilter(fp, filter1);
@@ -1376,8 +1376,8 @@ public class ElementsRequestExecutor {
     }
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     String filter1 = inputProcessor.getProcessingData().getRequestParameters().getFilter();
-    inputProcessor.checkFilter(filter1);
     String filter2 = inputProcessor.createEmptyStringIfNull(servletRequest.getParameter("filter2"));
+    inputProcessor.checkFilter(filter2);
     String combinedFilter = exeUtils.combineFiltersWithOr(filter1, filter2);
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);
     FilterExpression filterExpr1 = inputProcessor.getUtils().parseFilter(fp, filter1);

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -850,6 +850,10 @@ public class ExecutionUtils {
 
   /** Combines the two given filters with an OR operation. Used in /ratio computation. */
   public String combineFiltersWithOr(String firstFilter, String secondFilter) {
+    if (secondFilter.isBlank()) {
+      // definition of an empty combined filter if filter2 is empty
+      return "";
+    }
     return "(" + firstFilter + ") or (" + secondFilter + ")";
   }
 

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -850,8 +850,8 @@ public class ExecutionUtils {
 
   /** Combines the two given filters with an OR operation. Used in /ratio computation. */
   public String combineFiltersWithOr(String firstFilter, String secondFilter) {
-    if (secondFilter.isBlank()) {
-      // definition of an empty combined filter if filter2 is empty
+    if (firstFilter.isBlank() || secondFilter.isBlank()) {
+      // definition of an empty combined filter if filter1 or filter2 is empty
       return "";
     }
     return "(" + firstFilter + ") or (" + secondFilter + ")";

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -576,15 +576,16 @@ public class InputProcessor {
   }
 
   /**
-   * Checks the given filter parameter if it's null or blank.
+   * Checks the given filter parameter if it's null or blank. Currently used for filter2 parameter
+   * of /ratio processing.
    * 
    * @param filter parameter to be checked
    * @throws BadRequestException if the given filter parameter is null or blank.
    */
   public void checkFilter(String filter) throws BadRequestException {
-    if (null == filter || filter.isBlank()) {
+    if (null == filter || filter.isBlank() && processingData.isRatio()) {
       throw new BadRequestException(
-          "The filter parameter has to be defined when using a /ratio endpoint.");
+          "The filter2 parameter has to be defined when using a /ratio endpoint.");
     }
   }
   

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -576,6 +576,19 @@ public class InputProcessor {
   }
 
   /**
+   * Checks the given filter parameter if it's null or blank.
+   * 
+   * @param filter parameter to be checked
+   * @throws BadRequestException if the given filter parameter is null or blank.
+   */
+  public void checkFilter(String filter) throws BadRequestException {
+    if (null == filter || filter.isBlank()) {
+      throw new BadRequestException(
+          "The filter parameter has to be defined when using a /ratio endpoint.");
+    }
+  }
+  
+  /**
    * Checks the given keys and values parameters on their length and includes them in the
    * {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer#osmTag(String) osmTag(key)},
    * or {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer#osmTag(String, String)

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/ResourceParameters.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/ResourceParameters.java
@@ -15,8 +15,9 @@ public class ResourceParameters {
    * Checks the resource of the request and gives back a list of available parameters for this
    * resource.
    *
-   * <p>Note that some resources don't use this method, but implement their own checks.
-   * One example for this is the metadata request in
+   * <p>
+   * Note that some resources don't use this method, but implement their own checks. One example for
+   * this is the metadata request in
    * {@link MetadataRequestExecutor#executeGetMetadata(HttpServletRequest)}.
    */
   public static List<String> getResourceSpecificParams(HttpServletRequest servletRequest) {
@@ -35,10 +36,7 @@ public class ResourceParameters {
       possibleParams.add("groupByKeys");
       return possibleParams;
     } else if (uri.contains("/ratio")) {
-      if (null != servletRequest.getParameter("filter")) {
-        possibleParams.add("filter2");
-        return possibleParams;
-      }
+      possibleParams.add("filter2");
       possibleParams.add("keys2");
       possibleParams.add("types2");
       possibleParams.add("values2");

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -993,6 +993,16 @@ public class GetControllerTest {
   }
 
   @Test
+  public void getElementsCountRatioEmptyFilter2Test() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/elements/count/ratio?bboxes=8.685824,49.414756,8.686253,49.414955&"
+            + "filter=highway=*&time=2019-01-01",
+        JsonNode.class);
+    assertEquals(5.0, response.getBody().get("ratioResult").get(0).get("ratio").asDouble(), 1e-6);
+  }
+  
+  @Test
   public void ratioGroupByBoundaryFilterTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -991,16 +991,6 @@ public class GetControllerTest {
     assertEquals(0.060083, response.getBody().get("ratioResult").get(0).get("ratio").asDouble(),
         1e-6);
   }
-
-  @Test
-  public void getElementsCountRatioEmptyFilter2Test() {
-    TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/count/ratio?bboxes=8.685824,49.414756,8.686253,49.414955&"
-            + "filter=highway=*&time=2019-01-01",
-        JsonNode.class);
-    assertEquals(5.0, response.getBody().get("ratioResult").get(0).get("ratio").asDouble(), 1e-6);
-  }
   
   @Test
   public void ratioGroupByBoundaryFilterTest() {
@@ -1017,6 +1007,26 @@ public class GetControllerTest {
             false)
         .filter(jsonNode -> jsonNode.get("groupByObject").asText().equalsIgnoreCase("b2"))
         .findFirst().get().get("ratioResult").get(0).get("ratio").asDouble(), 1e-6);
+  }
+
+  @Test
+  public void getElementsCountRatioEmptyFilterTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/elements/count/ratio?bboxes=8.685824,49.414756,8.686253,49.414955&"
+            + "filter2=highway=*&time=2019-01-01",
+        JsonNode.class);
+    assertEquals(0.2, response.getBody().get("ratioResult").get(0).get("ratio").asDouble(), 1e-6);
+  }
+
+  @Test
+  public void ratioEmptyFilter2Test() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/elements/count/ratio?bboxes=8.687337,49.415067,8.687493,49.415172&"
+            + "time=2010-01-01&filter=building=*",
+        JsonNode.class);
+    assertEquals(400, response.getBody().get("status").asInt());
   }
 
   @Test


### PR DESCRIPTION
- [x] filter param can be null or empty (needs an adaption in the ohsome-filter library as well) - done with PR #38 

- [x] filter2 param has to be defined - throws exception if param is null or empty

- [x] marking types-keys-values code handling /ratio requests as deprecated

- [x] needs issue https://github.com/GIScience/ohsome-api/issues/28 to be fixed