### PR TITLE
improved osmCreateFeature tag handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## current master
 
+* data extraction: escape tags with `@` characters ([#40](https://github.com/GIScience/ohsome-api/issues/40))
+
 ## 1.2.3
 
 ### Bug Fixes

--- a/docs/response-parameters.rst
+++ b/docs/response-parameters.rst
@@ -11,6 +11,13 @@ Description of parameters that are present in every response.
 * ``attribution`` - copyrights and attribution
 * ``apiVersion`` - version of the ohsome API
 
+OSM Tags
+--------
+
+When requested, the result will contain OSM elements' tags as individual GeoJSON properties.
+
+.. note:: Any OSM tag with a key starting with the special `@` character (e.g.: `@osmId`), will be modified through the addition of another `@` at the start (the example would be changed to `@@osmId`).
+
 Aggregation Parameters
 ----------------------
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
@@ -83,12 +83,7 @@ public class DataRequestExecutor extends RequestExecutor {
     }
     TagTranslator tt = DbConnData.tagTranslator;
     String[] keys = requestParameters.getKeys();
-    int[] keysInt = new int[keys.length];
-    if (keys.length != 0) {
-      for (int i = 0; i < keys.length; i++) {
-        keysInt[i] = tt.getOSHDBTagKeyOf(keys[i]).toInt();
-      }
-    }
+    final Set<Integer> keysInt = ExecutionUtils.keysToKeysInt(keys, tt);
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     inputProcessor.processPropertiesParam();
     inputProcessor.processIsUnclippedParam();

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -108,12 +109,7 @@ public class ElementsRequestExecutor {
     RequestParameters requestParameters = processingData.getRequestParameters();
     TagTranslator tt = DbConnData.tagTranslator;
     String[] keys = requestParameters.getKeys();
-    int[] keysInt = new int[keys.length];
-    if (keys.length != 0) {
-      for (int i = 0; i < keys.length; i++) {
-        keysInt[i] = tt.getOSHDBTagKeyOf(keys[i]).toInt();
-      }
-    }
+    final Set<Integer> keysInt = ExecutionUtils.keysToKeysInt(keys, tt);
     final MapReducer<Feature> preResult;
     ExecutionUtils exeUtils = new ExecutionUtils(processingData);
     preResult = mapRed.map(snapshot -> {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/FlatMapExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/FlatMapExecutor.java
@@ -30,7 +30,7 @@ public class FlatMapExecutor implements Serializable {
   private final Set<SimpleFeatureType> simpleFeatureTypes;
   private final boolean requiresGeometryTypeCheck;
   private final FilterExpression filterExpression;
-  private final int[] keysInt;
+  private final Set<Integer> keysInt;
   private final boolean includeTags;
   private final boolean includeOSMMetadata;
   private final ElementsGeometry elementsGeometry;
@@ -41,7 +41,7 @@ public class FlatMapExecutor implements Serializable {
       ExecutionUtils exeUtils, boolean clipGeometries, String startTimestamp,
       InputProcessingUtils utils,
       Set<SimpleFeatureType> simpleFeatureTypes, boolean requiresGeometryTypeCheck,
-      FilterExpression filterExpression, int[] keysInt, boolean includeTags,
+      FilterExpression filterExpression, Set<Integer> keysInt, boolean includeTags,
       boolean includeOSMMetadata,
       ElementsGeometry elementsGeometry, String endTimestamp,
       boolean isContainingSimpleFeatureTypes) {


### PR DESCRIPTION
The original version pushes all OSHDBTags into the features properties map  and  they need then to be  extracted again for converting to OSMTags.

This pull request makes this extraction easier by not  pushing each tag individual into the features properties, but push that as a whole into a `@tags` properties. This makes the handling of those tags easier.

