### PR TITLE
allowing pipe sign in GET requests

### DIFF
--- a/src/main/java/org/heigit/ohsome/ohsomeapi/config/TomcatConfig.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/config/TomcatConfig.java
@@ -1,0 +1,25 @@
+package org.heigit.ohsome.ohsomeapi.config;
+
+import org.apache.catalina.connector.Connector;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Used to allow the not encoded pipe sign (|) in request URLs. */
+@Configuration
+public class TomcatConfig {
+  
+  @Bean
+  public ConfigurableServletWebServerFactory webServerFactory() {
+      TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+      factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+          @Override
+          public void customize(Connector connector) {
+              connector.setProperty("relaxedQueryChars", "|");
+          }
+      });
+      return factory;
+  }
+}


### PR DESCRIPTION
adding of TomcatConfig class which defines the pipe sign as a valid property
needed due to recent security changes (https://bugzilla.redhat.com/show_bug.cgi?id=1397484) in Tomcat
fixes #59