### PR TITLE
pipe sign bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## current master
 
+## 1.1.1
+
+### Bug Fixes
+
+* allowing not encoded pipe sign in GET requests ([#60](https://github.com/GIScience/ohsome-api/pull/60))
+
 
 ## 1.1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <name>ohsome API</name>
   <description>A public Web-RESTful-API for "ohsome" OpenStreetMap history data.</description>
   <packaging>jar</packaging>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
 
   <properties>
     <apachecommons-csv.version>1.6</apachecommons-csv.version>

--- a/src/main/java/org/heigit/ohsome/ohsomeapi/config/TomcatConfig.java
+++ b/src/main/java/org/heigit/ohsome/ohsomeapi/config/TomcatConfig.java
@@ -1,0 +1,25 @@
+package org.heigit.ohsome.ohsomeapi.config;
+
+import org.apache.catalina.connector.Connector;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Used to allow the not encoded pipe sign (|) in request URLs. */
+@Configuration
+public class TomcatConfig {
+  
+  @Bean
+  public ConfigurableServletWebServerFactory webServerFactory() {
+      TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+      factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+          @Override
+          public void customize(Connector connector) {
+              connector.setProperty("relaxedQueryChars", "|");
+          }
+      });
+      return factory;
+  }
+}


### PR DESCRIPTION
backport into 1.1: fix for #59 (usage of unencoded pipe characters in GET requests)