### PR TITLE
upgrade ohsome-filter to 1.3.0

### DIFF
--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -172,6 +172,11 @@ Here's some useful examples for querying some OSM features:
     |                  |                                                        | | with the ``noname`` tag    |
     |                  |                                                        | | in OSM.                    |
     +------------------+--------------------------------------------------------+------------------------------+
+    | | implausibly    | | ``geometry:polygon and building=* and building!=no`` | | The currently largest      |
+    | | large          | | ``and area:(1E6..)``                                 | | building by footprint area |
+    | | buildings      |                                                        | | is a car factory building  |
+    |                  |                                                        | | measuring about 887,800 m².|
+    +------------------+--------------------------------------------------------+------------------------------+
      
 |
 

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -41,19 +41,34 @@ Selectors
     |                        | | given osm type                   |                        |
     +------------------------+------------------------------------+------------------------+
     | ``id:osm-id``          | | matches all entities with the    | ``id:1234``            |
-    |                        | | given osm id [#]_                |                        |
+    |                        | | given osm id [1]_                |                        |
+    +------------------------+------------------------------------+------------------------+
+    | ``id:osm-type/osm-id`` | | matches the entity with the given| ``id:node/1234``       |
+    |                        | | osm type and id                  |                        |
     +------------------------+------------------------------------+------------------------+
     | ``id:(id list)``       | | matches all entities with the    | ``id:(1, 42, 1234)``   |
-    |                        | | given osm ids                    |                        |
+    |                        | | given osm ids [1]_               |                        |
+    +------------------------+------------------------------------+------------------------+
+    | ``id:(id list)``       | | matches all entities with the    | ``id:(node/1, way/3)`` |
+    |                        | | given osm types and ids          |                        |
     +------------------------+------------------------------------+------------------------+
     | ``id:(id range)``      | | matches all entities with an id  | ``id:(1 .. 9999)``     |
-    |                        | | matching the given id range      |                        |
+    |                        | | matching the given id range [2]_ |                        |
     +------------------------+------------------------------------+------------------------+
     | ``geometry:geom-type`` | | matches anything which has a     | ``geometry:polygon``   |
     |                        | | geometry of the given type       |                        |
     |                        | | (point, line, polygon, or other) |                        |
     +------------------------+------------------------------------+------------------------+
-.. [#] keep in mind that osm ids are not unique between osm types. In order to exclude only a specific object the id needs to be combined with an osm type filter e.g. ``type:node and id:1234``
+    | ``area:(from..to)``    | | matches features with a geometry | ``area:(1.0 .. 1E6)``  |
+    |                        | | having an area (measured in m²)  |                        |
+    |                        | | in the given range [2]_          |                        |
+    +------------------------+------------------------------------+------------------------+
+    | ``length:(from..to)``  | | matches features with a geometry | ``length:( .. 100)``   |
+    |                        | | having a length (measured in m)  |                        |
+    |                        | | in the given range [2]_          |                        |
+    +------------------------+------------------------------------+------------------------+
+.. [1] Keep in mind that osm ids are not unique between osm types. In order to include only a specific object the id needs to be used together with an osm type filter. Alternatively, one can also use the combined type+id filter (e.g. `id:node/1234`).
+.. [2] The lower or upper bound of a range may be omitted to indicate that the values are only to be limited to be "up to" or "starting from" the given value, respectively. For example: `id:(10..)` will accept all entities with an id of 10 or higher.
 
 |
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <jsonpath.version>2.2.0</jsonpath.version>
     <jts2geojson.version>0.13.0</jts2geojson.version>
     <mavenjar.version>3.2.0</mavenjar.version>
-    <ohsome-filter.version>1.2.0</ohsome-filter.version>
+    <ohsome-filter.version>1.3.0</ohsome-filter.version>
     <opencsv.version>4.0</opencsv.version>
     <oshdb.version>0.5.9</oshdb.version>
     <springboot.version>2.0.3.RELEASE</springboot.version>


### PR DESCRIPTION
[new features](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter/-/blob/master/CHANGELOG.md#anchor-130) included here are:

* new filter: geometry filters return only features with a certain range of length (in meters) or area (in m²). example: `area:(10..20)` or `length:(..123)`
* new filter: id filter allows to select by type and id in a single expression (syntax: `id:node/42`)
* be a bit more forgiving with extra or omitted whitespace around parentheses

todo:
* [x] update ohsome-api documentation