### PR TITLE
updating tests to use filter parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@ Changelog
 
 ## 1.4.0-SNAPSHOT (current master)
 
+
 ### Bug Fixes
 
+* update all tests using the filter parameter instead of deprecated types, keys, values ([#98])
 * fix some invalid filters in the default swagger examples ([#111])
 
+[#98]: https://github.com/GIScience/ohsome-api/issues/98
 [#111]: https://github.com/GIScience/ohsome-api/issues/111
 
 

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -93,16 +93,16 @@ public class DataExtractionTest {
 
   // this needs a fix in the OSHDB to work
   // see https://github.com/GIScience/oshdb/issues/338
-//  @Test
-//  public void elementsGeomSimpleFeaturesOtherLineTest() {
-//    TestRestTemplate restTemplate = new TestRestTemplate();
-//    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port 
-//        + "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994"
-//        + "&time=2019-01-02&filter=building=* and (geometry:other or geometry:line)",
-//        JsonNode.class);
-//    assertTrue("GeometryCollection"
-//        .equals(response.getBody().get("features").get(0).get("geometry").get("type").asText()));
-//  }
+  //  @Test
+  //  public void elementsGeomSimpleFeaturesOtherLineTest() {
+  //    TestRestTemplate restTemplate = new TestRestTemplate();
+  //    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port 
+  //        + "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994"
+  //        + "&time=2019-01-02&filter=building=* and (geometry:other or geometry:line)",
+  //        JsonNode.class);
+  //    assertTrue("GeometryCollection"
+  //        .equals(response.getBody().get("features").get(0).get("geometry").get("type").asText()));
+  //  }
 
   @Test
   public void elementsGeomUsingNoTagsTest() {
@@ -141,18 +141,18 @@ public class DataExtractionTest {
 
   // this needs a fix in the OSHDB to work
   // see https://github.com/GIScience/oshdb/issues/338
-//  @Test
-//  public void elementsClipGeometryParamTrueFalseTest() {
-//    TestRestTemplate restTemplate = new TestRestTemplate();
-//    String uri = "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&time=2018-01-02"
-//        + "&filter=building=* and (geometry:other or geometry:line)";
-//    ResponseEntity<JsonNode> emptyFeatureResponse =
-//        restTemplate.getForEntity(server + port + uri + "&clipGeometry=false", JsonNode.class);
-//    ResponseEntity<JsonNode> featureResponse =
-//        restTemplate.getForEntity(server + port + uri + "&clipGeometry=true", JsonNode.class);
-//    assertTrue(emptyFeatureResponse.getBody().get("features").size() == 0);
-//    assertTrue(featureResponse.getBody().get("features").size() == 1);
-//  }
+  //  @Test
+  //  public void elementsClipGeometryParamTrueFalseTest() {
+  //    TestRestTemplate restTemplate = new TestRestTemplate();
+  //    String uri = "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&time=2018-01-02"
+  //        + "&filter=building=* and (geometry:other or geometry:line)";
+  //    ResponseEntity<JsonNode> emptyFeatureResponse =
+  //        restTemplate.getForEntity(server + port + uri + "&clipGeometry=false", JsonNode.class);
+  //    ResponseEntity<JsonNode> featureResponse =
+  //        restTemplate.getForEntity(server + port + uri + "&clipGeometry=true", JsonNode.class);
+  //    assertTrue(emptyFeatureResponse.getBody().get("features").size() == 0);
+  //    assertTrue(featureResponse.getBody().get("features").size() == 1);
+  //  }
 
   /*
    * ./elementsFullHistory/geometry|bbox|centroid tests

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -167,7 +167,7 @@ public class DataExtractionTest {
             + "&filter=type:way and building=residential",
         JsonNode.class);
     assertTrue(Helper.getFeatureByIdentifier(response, "@osmId", "way/295135436") != null);
-    assertEquals(7, Helper.getFeatureByIdentifier(response, "@validTo", "2015-05-05T06:59:35Z")
+    assertEquals(6, Helper.getFeatureByIdentifier(response, "@validTo", "2015-05-05T06:59:35Z")
         .get("properties").size());
   }
 
@@ -209,7 +209,7 @@ public class DataExtractionTest {
     map.add("time", "2017-01-01,2017-07-01");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elementsFullHistory/centroid", map, JsonNode.class);
-    assertEquals(4, Helper.getFeatureByIdentifier(response, "@osmId", "way/295135455")
+    assertEquals(3, Helper.getFeatureByIdentifier(response, "@osmId", "way/295135455")
         .get("properties").size());
   }
 

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -54,30 +54,29 @@ public class DataExtractionTest {
   @Test
   public void elementsGeometryTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/geometry?bboxes=8.67452,49.40961,8.70392,49.41823&types=way"
-            + "&keys=building&values=residential&time=2015-01-01&properties=metadata",
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port 
+        + "/elements/geometry?bboxes=8.67452,49.40961,8.70392,49.41823"
+        + "&time=2015-01-01&properties=metadata&filter=type:way and building=residential",
         JsonNode.class);
     JsonNode feature = Helper.getFeatureByIdentifier(response, "@osmId", "way/140112811");
-    assertEquals(7, feature.get("properties").size());
+    assertEquals(6, feature.get("properties").size());
   }
 
   @Test
   public void elementsGeomUsingOneTagTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/elements/geometry?bboxes=8.67452,49.40961,8.70392,49.41823&types=way&keys=building"
-        + "&values=residential&time=2015-12-01&properties=metadata", JsonNode.class);
+        + "/elements/geometry?bboxes=8.67452,49.40961,8.70392,49.41823&time=2015-12-01"
+        + "&properties=metadata&filter=type:way and building=residential", JsonNode.class);
     assertTrue(Helper.getFeatureByIdentifier(response, "@osmId", "way/140112811") != null);
   }
 
   @Test
   public void elementsGeomUsingMultipleTagsTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port
-            + "/elements/geometry?bboxes=8.67559,49.40853,8.69379,49.4231&types=way&keys=highway,"
-            + "name,maxspeed&values=residential&time=2015-10-01&properties=metadata",
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port 
+        + "/elements/geometry?bboxes=8.67559,49.40853,8.69379,49.4231&time=2015-10-01"
+        + "&properties=metadata&filter=type:way and highway=residential and maxspeed=* and name=*",
         JsonNode.class);
     assertTrue(Helper.getFeatureByIdentifier(response, "@osmId", "way/4084860") != null);
   }
@@ -85,30 +84,32 @@ public class DataExtractionTest {
   @Test
   public void elementsGeomUnclippedSimpleFeaturesTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port
-            + "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&types=other,line&"
-            + "keys=building&showMetadata=true&properties=unclipped&time=2019-01-02",
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&properties=unclipped"
+        + "&time=2019-01-02&filter=building=* and (geometry:other or geometry:line)",
         JsonNode.class);
     assertTrue(response.getBody().get("features").size() == 0);
   }
 
-  @Test
-  public void elementsGeomSimpleFeaturesOtherLineTest() {
-    TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&types=other,line&"
-        + "keys=building&showMetadata=true&time=2019-01-02", JsonNode.class);
-    assertTrue("GeometryCollection"
-        .equals(response.getBody().get("features").get(0).get("geometry").get("type").asText()));
-  }
+  // this needs a fix in the OSHDB to work
+  // see https://github.com/GIScience/oshdb/issues/338
+//  @Test
+//  public void elementsGeomSimpleFeaturesOtherLineTest() {
+//    TestRestTemplate restTemplate = new TestRestTemplate();
+//    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port 
+//        + "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994"
+//        + "&time=2019-01-02&filter=building=* and (geometry:other or geometry:line)",
+//        JsonNode.class);
+//    assertTrue("GeometryCollection"
+//        .equals(response.getBody().get("features").get(0).get("geometry").get("type").asText()));
+//  }
 
   @Test
   public void elementsGeomUsingNoTagsTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.67452,49.40961,8.70392,49.41823");
-    map.add("types", "node");
+    map.add("filter", "type:node");
     map.add("time", "2016-02-05");
     map.add("properties", "metadata");
     ResponseEntity<JsonNode> response =
@@ -119,10 +120,9 @@ public class DataExtractionTest {
   @Test
   public void elementsBboxTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/bbox?bboxes=8.67452,49.40961,8.70392,49.41823&types=way"
-            + "&keys=building&values=residential&time=2015-01-01&properties=metadata",
-        JsonNode.class);
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port 
+        + "/elements/bbox?bboxes=8.67452,49.40961,8.70392,49.41823&time=2015-01-01"
+        + "&properties=metadata&filter=type:way and building=residential", JsonNode.class);
     JsonNode featureGeom =
         Helper.getFeatureByIdentifier(response, "@osmId", "way/294644468").get("geometry");
     assertEquals("Polygon", featureGeom.get("type").asText());
@@ -132,26 +132,27 @@ public class DataExtractionTest {
   @Test
   public void elementsCentroidTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/centroid?bboxes=8.67452,49.40961,8.70392,49.41823&types=way"
-            + "&keys=building&values=residential&time=2015-01-01&properties=metadata",
-        JsonNode.class);
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity( server + port 
+        + "/elements/centroid?bboxes=8.67452,49.40961,8.70392,49.41823&time=2015-01-01"
+        + "&properties=metadata&filter=type:way and building=residential", JsonNode.class);
     assertEquals(2, Helper.getFeatureByIdentifier(response, "@osmId", "way/294644468")
         .get("geometry").get("coordinates").size());
   }
 
-  @Test
-  public void elementsClipGeometryParamTrueFalseTest() {
-    TestRestTemplate restTemplate = new TestRestTemplate();
-    String uri = "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&types=other,"
-        + "line&keys=building&showMetadata=true&time=2018-01-02";
-    ResponseEntity<JsonNode> emptyFeatureResponse =
-        restTemplate.getForEntity(server + port + uri + "&clipGeometry=false", JsonNode.class);
-    ResponseEntity<JsonNode> featureResponse =
-        restTemplate.getForEntity(server + port + uri + "&clipGeometry=true", JsonNode.class);
-    assertTrue(emptyFeatureResponse.getBody().get("features").size() == 0);
-    assertTrue(featureResponse.getBody().get("features").size() == 1);
-  }
+  // this needs a fix in the OSHDB to work
+  // see https://github.com/GIScience/oshdb/issues/338
+//  @Test
+//  public void elementsClipGeometryParamTrueFalseTest() {
+//    TestRestTemplate restTemplate = new TestRestTemplate();
+//    String uri = "/elements/geometry?bboxes=8.700582,49.4143039,8.701247,49.414994&time=2018-01-02"
+//        + "&filter=building=* and (geometry:other or geometry:line)";
+//    ResponseEntity<JsonNode> emptyFeatureResponse =
+//        restTemplate.getForEntity(server + port + uri + "&clipGeometry=false", JsonNode.class);
+//    ResponseEntity<JsonNode> featureResponse =
+//        restTemplate.getForEntity(server + port + uri + "&clipGeometry=true", JsonNode.class);
+//    assertTrue(emptyFeatureResponse.getBody().get("features").size() == 0);
+//    assertTrue(featureResponse.getBody().get("features").size() == 1);
+//  }
 
   /*
    * ./elementsFullHistory/geometry|bbox|centroid tests
@@ -161,9 +162,9 @@ public class DataExtractionTest {
   public void elementsFullHistoryGeometryTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elementsFullHistory/geometry?bboxes=8.67452,49.40961,8.70392,49.41823&"
-            + "types=way&keys=building&values=residential&properties=metadata&time=2015-01-01,"
-            + "2015-07-01&showMetadata=true",
+        server + port + "/elementsFullHistory/geometry?bboxes=8.67452,49.40961,8.70392,49.41823"
+            + "&properties=metadata&time=2015-01-01,2015-07-01"
+            + "&filter=type:way and building=residential",
         JsonNode.class);
     assertTrue(Helper.getFeatureByIdentifier(response, "@osmId", "way/295135436") != null);
     assertEquals(7, Helper.getFeatureByIdentifier(response, "@validTo", "2015-05-05T06:59:35Z")
@@ -174,9 +175,8 @@ public class DataExtractionTest {
   public void elementsFullHistoryGeometryWithTagsTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elementsFullHistory/geometry?bboxes=8.67494,49.417032,8.676136,49.419576&"
-            + "types=way&keys=brand&values=Aldi Süd&properties=tags&time=2017-01-01,2018-01-01&"
-            + "showMetadata=true",
+        server + port + "/elementsFullHistory/geometry?bboxes=8.67494,49.417032,8.676136,49.419576"
+            + "&properties=tags&time=2017-01-01,2018-01-01&filter=type:way and brand=\"Aldi Süd\"",
         JsonNode.class);
     assertTrue(
         Helper.getFeatureByIdentifier(response, "@validFrom", "2017-01-18T17:38:06Z") != null);
@@ -189,9 +189,7 @@ public class DataExtractionTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.67494,49.417032,8.676136,49.419576");
-    map.add("types", "way");
-    map.add("keys", "brand");
-    map.add("values", "Aldi Süd");
+    map.add("filter", "type:way and brand=\"Aldi Süd\"");
     map.add("time", "2017-01-01,2018-01-01");
     map.add("properties", "tags,metadata");
     ResponseEntity<JsonNode> response = restTemplate
@@ -207,10 +205,8 @@ public class DataExtractionTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.67452,49.40961,8.70392,49.41823");
-    map.add("types", "way");
+    map.add("filter", "type:way and building=residential");
     map.add("time", "2017-01-01,2017-07-01");
-    map.add("keys", "building");
-    map.add("values", "residential");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elementsFullHistory/centroid", map, JsonNode.class);
     assertEquals(4, Helper.getFeatureByIdentifier(response, "@osmId", "way/295135455")
@@ -261,7 +257,7 @@ public class DataExtractionTest {
   public void postDataExtractionWithSpecificParameterOfOtherSpecificResourceTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    map.add("values2", "primary");
+    map.add("filter2", "highway=primary");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/geometry", map, JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.ArrayList;

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -1,10 +1,8 @@
 package org.heigit.ohsome.ohsomeapi.controller;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import java.io.IOException;
@@ -648,7 +646,7 @@ public class GetControllerTest {
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/users/count/groupBy/boundary?bboxes=a:8.67452,49.40961,8.70392,49.41823|"
         + "b:8.67,49.39941,8.69545,49.4096&time=2014-01-01,2015-01-01"
-        + "&filter=highway=* and type:way", JsonNode.class);
+        + "&filter=building=* and type:way", JsonNode.class);
     assertEquals(29,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -772,7 +770,7 @@ public class GetControllerTest {
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(3, headers.size());
+    assertEquals(4, headers.size());
     assertEquals(expectedValue, Double.parseDouble(records.get(0).get("RELATION")),
         expectedValue * deltaPercentage);
   }
@@ -784,7 +782,7 @@ public class GetControllerTest {
     String responseBody = getResponseBody("/elements/count/groupBy/boundary?"
         + "bboxes=8.672445,49.418337,8.673196,49.419087|"
         + "8.670868,49.418892,8.672188,49.419216&time=2017-05-01&format=csv"
-        + "&filter=type:node and bycicle_parking=stands");
+        + "&filter=type:node and bicycle_parking=stands");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -852,7 +850,7 @@ public class GetControllerTest {
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(3, headers.size());
+    assertEquals(4, headers.size());
     assertEquals(expectedValue, Double.parseDouble(records.get(0).get("WAY")),
         expectedValue * deltaPercentage);
   }
@@ -934,8 +932,7 @@ public class GetControllerTest {
     final List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertFalse(headers.containsKey("NODE"));
-    assertEquals(3, headers.size());
+    assertEquals(4, headers.size());
     assertEquals(expectedValue1, Double.parseDouble(records.get(0).get("WAY")),
         expectedValue1 * deltaPercentage);
     assertEquals(expectedValue2, Double.parseDouble(records.get(0).get("RELATION")),
@@ -959,17 +956,17 @@ public class GetControllerTest {
 
   @Test
   public void getElementsAreaGroupByTypeCsvTest() throws IOException {
-    // expect result to have 1 entry row, with 3 columns
+    // expect result to have 1 entry row, with 4 columns
     final double expectedValue = 1984.58;
     String responseBody =
         getResponseBody("/elements/area/groupBy/type?bcircles=8.689054,49.402481,80&"
-            + "format=csv&time=2018-01-01&filter=highway=* and (type:way or type:relation)");
+            + "format=csv&time=2018-01-01&filter=building=* and (type:way or type:relation)");
     // way in geojson.io sq meters: 23.97
     // relation in geojson.io sq meters: 5399.27; in response:6448.93; in qgis 5393.5
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(3, headers.size());
+    assertEquals(4, headers.size());
     assertEquals(expectedValue, Double.parseDouble(records.get(0).get("WAY")),
         expectedValue * deltaPercentage);
   }
@@ -1029,7 +1026,7 @@ public class GetControllerTest {
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(4, headers.size());
+    assertEquals(5, headers.size());
     assertEquals(expectedValue, Double.parseDouble(records.get(0).get("NODE")),
         expectedValue * deltaPercentage);
   }
@@ -1056,11 +1053,11 @@ public class GetControllerTest {
     final double expectedValue = 1.0;
     String responseBody = getResponseBody("users/count/groupBy/type?"
         + "bboxes=8.700609,49.409336,8.701488,49.409591&format=csv&time=2010-01-01/2013-01-01/P1Y"
-        + "&filter=(type:way or type:node) and addr:housenumber=* and addr:street=Plöck");
+        + "&filter=(type:way or type:node) and addr:housenumber=* and addr:street=\"Plöck\"");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(4, headers.size());
+    assertEquals(5, headers.size());
     assertEquals(expectedValue, Double.parseDouble(records.get(2).get("WAY")),
         expectedValue * deltaPercentage);
   }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -341,8 +341,8 @@ public class GetControllerTest {
     final double expectedValue = 15198.89;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/length?bboxes=8.67452,49.40961,8.70392,49.41823&types=way"
-            + "&time=2012-01-01&keys=highway&values=residential",
+        server + port + "/elements/length?bboxes=8.67452,49.40961,8.70392,49.41823"
+            + "&time=2012-01-01&filter=type:way and highway=residential",
         JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
         expectedValue * deltaPercentage);
@@ -355,7 +355,7 @@ public class GetControllerTest {
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port
             + "/elements/length/groupBy/boundary?bboxes=8.695443,49.408928,8.695636,49.409151|"
-            + "8.699262,49.409451,8.701547,49.412205&types=way&time=2014-08-21&keys=highway",
+            + "8.699262,49.409451,8.701547,49.412205&time=2014-08-21&filter=type:way and highway=*",
         JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -371,7 +371,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/length/groupBy/boundary/groupBy/tag?bboxes=8.68086,49.39948,8.69401,49.40609"
-        + "&types=way&time=2017-11-25&keys=highway&groupByKey=highway", JsonNode.class);
+        + "&time=2017-11-25&groupByKey=highway&filter=type:way and highway=*", JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
@@ -388,7 +388,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port + "/elements/length/groupBy/type?bboxes=8.701665,49.408802,8.703999,49.409553"
-            + "&types=way,relation&time=2014-08-21&keys=highway",
+            + "&time=2014-08-21&filter=highway=* and (type:way or type:relation)",
         JsonNode.class);
     assertEquals(expectedValue,
         StreamSupport
@@ -405,7 +405,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port + "/elements/length/groupBy/key?bboxes=8.67181,49.40434,8.67846,49.40878"
-            + "&types=way&time=2016-08-21&groupByKeys=highway,railway",
+            + "&time=2016-08-21&groupByKeys=highway,railway&filter=type:way",
         JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -420,8 +420,8 @@ public class GetControllerTest {
     final double expectedValue = 373.51;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/elements/length/groupBy/tag?bboxes=8.70773,49.40832,8.71413,49.41092&types=way"
-        + "&time=2016-08-21&groupByKey=highway", JsonNode.class);
+        + "/elements/length/groupBy/tag?bboxes=8.70773,49.40832,8.71413,49.41092&time=2016-08-21"
+        + "&groupByKey=highway&filter=type:way", JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
@@ -436,7 +436,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port + "/elements/length/ratio?bboxes=8.67567,49.40695,8.69434,49.40882"
-            + "&types=way&time=2011-12-13&keys=highway&keys2=railway",
+            + "&time=2011-12-13&&filter=type:way and highway=*&filter2=railway=*",
         JsonNode.class);
     assertEquals(expectedValue,
         response.getBody().get("ratioResult").get(0).get("ratio").asDouble(),
@@ -449,7 +449,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port + "/elements"
         + "/length/ratio/groupBy/boundary?bboxes=8.67829,49.39807,8.69061,49.40578|"
-        + "8.68306,49.42407,8.68829,49.42711&types=way&time=2012-12-22&keys=highway&keys2=railway",
+        + "8.68306,49.42407,8.68829,49.42711&time=2012-12-22&filter=type:way and highway=*"
+        + "&filter2=railway=*",
         JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(
@@ -467,7 +468,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port + "/elements/length/density?bboxes=8.70538,49.40464,8.71264,49.41042"
-            + "&types=way&time=2013-01-04&keys=highway",
+            + "&time=2013-01-04&filter=type:way and highway=*",
         JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
         expectedValue * deltaPercentage);
@@ -479,7 +480,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/length/density/groupBy/type?bboxes=8.68242,49.40059,8.68732,49.4059"
-        + "&types=way,node&time=2015-03-25", JsonNode.class);
+        + "&time=2015-03-25&filter=type:way or type:node", JsonNode.class);
     assertEquals(expectedValue,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -495,7 +496,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/length/density/groupBy/tag?bboxes=8.66972,49.40453,8.67564,49.4076"
-        + "&types=way&time=2016-01-17&groupByKey=railway", JsonNode.class);
+        + "&time=2016-01-17&groupByKey=railway&filter=type:way", JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
@@ -511,7 +512,7 @@ public class GetControllerTest {
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port
             + "/elements/length/density/groupBy/boundary?bboxes=8.69079,49.40129,8.69238,49.40341|"
-            + "8.67504,49.4119,8.67813,49.41668&types=way&time=2017-05-30&keys=highway",
+            + "8.67504,49.4119,8.67813,49.41668&time=2017-05-30&filter=type:way and highway=*",
         JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -527,8 +528,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/length/density/groupBy/boundary/groupBy/tag?bboxes=b1:8.68086,49.39948,8.69401"
-        + ",49.40609|b2:8.68081,49.39943,8.69408,49.40605&types=way&time=2017-10-08&keys=highway&"
-        + "groupByKey=highway", JsonNode.class);
+        + ",49.40609|b2:8.68081,49.39943,8.69408,49.40605&time=2017-10-08&groupByKey=highway"
+        + "&filter=type:way and highway=*", JsonNode.class);
     assertEquals(expectedValue,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -546,21 +547,20 @@ public class GetControllerTest {
   @Test
   public void getUsersCountTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response =
-        restTemplate
-            .getForEntity(
-                server + port + "/users/count?bboxes=8.67452,49.40961,8.70392,49.41823&types=way"
-                    + "&time=2014-01-01,2015-01-01&keys=building&values=residential",
-                JsonNode.class);
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/users/count?bboxes=8.67452,49.40961,8.70392,49.41823&"
+            + "&time=2014-01-01,2015-01-01&filter=type:way and building=residential",
+        JsonNode.class);
     assertEquals(5, response.getBody().get("result").get(0).get("value").asInt());
   }
 
   @Test
   public void getUsersCountGroupByTypeTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/users/count/groupBy/type?bboxes=8.67,49.39941,8.69545,49.4096&types=way,relation"
-        + "&time=2014-01-01,2015-01-01&keys=building", JsonNode.class);
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/users/count/groupBy/type?bboxes=8.67,49.39941,8.69545,49.4096"
+            + "&time=2014-01-01,2015-01-01&filter=(type:way or type:relation) and building=*",
+        JsonNode.class);
     assertEquals(30,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -573,8 +573,8 @@ public class GetControllerTest {
   public void getUsersCountGroupByKeyTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/users/count/groupBy/key?bboxes=8.67,49.39941,8.69545,49.4096&types=way"
-            + "&time=2014-01-01,2015-01-01&groupByKeys=building",
+        server + port + "/users/count/groupBy/key?bboxes=8.67,49.39941,8.69545,49.4096"
+            + "&time=2014-01-01,2015-01-01&groupByKeys=building&filter=type:way",
         JsonNode.class);
     assertEquals(30,
         StreamSupport
@@ -588,8 +588,8 @@ public class GetControllerTest {
   public void getUsersCountGroupByTagTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/users/count/groupBy/tag?bboxes=8.67,49.39941,8.69545,49.4096&types=way"
-            + "&time=2014-01-01,2015-01-01&groupByKey=building",
+        server + port + "/users/count/groupBy/tag?bboxes=8.67,49.39941,8.69545,49.4096"
+            + "&time=2014-01-01,2015-01-01&groupByKey=building&filter=type:way",
         JsonNode.class);
     assertEquals(29, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -603,8 +603,8 @@ public class GetControllerTest {
     final double expectedValue = 14.33;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/users/count/density?bboxes=8.67,49.39941,8.69545,49.4096&types=way"
-            + "&time=2014-01-01,2015-01-01&keys=building",
+        server + port + "/users/count/density?bboxes=8.67,49.39941,8.69545,49.4096"
+            + "&time=2014-01-01,2015-01-01&filter=type:way and building=*",
         JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
         expectedValue * deltaPercentage);
@@ -614,9 +614,10 @@ public class GetControllerTest {
   public void getUsersCountDensityGroupByTypeTest() {
     final double expectedValue = 3.82;
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/users/count/density/groupBy/type?bboxes=8.67,49.39941,8.69545,49.4096&types=way,"
-        + "relation&time=2014-01-01,2015-01-01&keys=building", JsonNode.class);
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/users/count/density/groupBy/type?bboxes=8.67,49.39941,8.69545,49.4096"
+            + "&time=2014-01-01,2015-01-01&filter=(type:way or type:relation) and building=*",
+        JsonNode.class);
     assertEquals(expectedValue,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -631,8 +632,8 @@ public class GetControllerTest {
     final double expectedValue = 26.75;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/users/count/density/groupBy/tag?bboxes=8.67,49.39941,8.69545,49.4096&types=way"
-        + "&time=2014-01-01,2015-01-01&groupByKey=building&showMetadata=true", JsonNode.class);
+        + "/users/count/density/groupBy/tag?bboxes=8.67,49.39941,8.69545,49.4096"
+        + "&time=2014-01-01,2015-01-01&groupByKey=building&filter=type:way", JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
@@ -646,8 +647,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/users/count/groupBy/boundary?bboxes=a:8.67452,49.40961,8.70392,49.41823|"
-        + "b:8.67,49.39941,8.69545,49.4096&types=way&time=2014-01-01,2015-01-01&showMetadata=true"
-        + "&keys=building", JsonNode.class);
+        + "b:8.67,49.39941,8.69545,49.4096&time=2014-01-01,2015-01-01"
+        + "&filter=highway=* and type:way", JsonNode.class);
     assertEquals(29,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -668,8 +669,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/users/count/density/groupBy/boundary?bboxes=a:8.67452,49.40961,8.70392,49.41823|"
-        + "b:8.67,49.39941,8.69545,49.4096&types=way&time=2014-01-01,2015-01-01&showMetadata=true"
-        + "&keys=building", JsonNode.class);
+        + "b:8.67,49.39941,8.69545,49.4096&time=2014-01-01,2015-01-01"
+        + "&filter=type:way and building=*", JsonNode.class);
     assertEquals(expectedValue,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -687,7 +688,7 @@ public class GetControllerTest {
     // expect result to have 1 entry row, with 2 columns
     final double expectedValue = 5.0;
     String responseBody = getResponseBody("/elements/count?"
-        + "bboxes=8.689086,49.40268,8.689606,49.402973&types=way&time=2019-01-01" + "&format=csv");
+        + "bboxes=8.689086,49.40268,8.689606,49.402973&time=2019-01-01&format=csv&filter=type:way");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -701,9 +702,8 @@ public class GetControllerTest {
     // expect result to have 1 entry row, with 2 columns
     // bbox contains 2 shops(bbox 1 ~ 0.01km²)
     final double expectedValue = 215.87;
-    String responseBody =
-        getResponseBody("/elements/count/density?" + "bboxes=8.6889,49.39281,8.69025,49.39366&"
-            + "types=node&time=2017-01-01&keys=shop&format=csv");
+    String responseBody = getResponseBody("/elements/count/density?bboxes=8.6889,49.39281,8.69025,"
+        + "49.39366&time=2017-01-01&format=csv&filter=type:node and shop=*");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -718,8 +718,8 @@ public class GetControllerTest {
     // bbox 1 contains 3, bbox 2 contains 0 residential buildings (bbox 1 ~ 1km²)
     final double expectedValue = 3.76;
     String responseBody = getResponseBody("/elements/count/density/groupBy/boundary?"
-        + "bboxes=8.678,49.41254,8.69074,49.4203|8.67959,49.41039,8.68092,49.41125&"
-        + "types=way&time=2017-07-01&keys=building&values=residential&format=csv");
+        + "bboxes=8.678,49.41254,8.69074,49.4203|8.67959,49.41039,8.68092,49.41125"
+        + "&time=2017-07-01&format=csv&filter=type:way and building=residential");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -735,8 +735,8 @@ public class GetControllerTest {
     final double expectedValue = 1455.77;
     String responseBody = getResponseBody("/elements/count/density/groupBy/boundary/"
         + "groupBy/tag?bboxes=b1:8.692826,49.399133,8.693497,49.399388"
-        + "|b2:8.69376,49.398376,8.69443,49.39863&types=way&time=2016-11-09&keys=building&"
-        + "groupByKey=building&format=csv&groupByValues=garage,residential");
+        + "|b2:8.69376,49.398376,8.69443,49.39863&time=2016-11-09&groupByKey=building&format=csv"
+        + "&groupByValues=garage,residential&filter=type:way and building=*");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -752,7 +752,7 @@ public class GetControllerTest {
     final double expectedValue = 35.08;
     String responseBody = getResponseBody("/elements/count/density/groupBy/tag?"
         + "bboxes=8.687208,49.403608,8.690481,49.404687&format=csv&"
-        + "groupByKey=building&groupByValues=church,synagogue&time=2019-01-01&types=way");
+        + "groupByKey=building&groupByValues=church,synagogue&time=2019-01-01&filter=type:way");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -767,8 +767,8 @@ public class GetControllerTest {
     // bbox contains 1 way and 1 relation with highway=pedestrian
     final double expectedValue = 2556.22;
     String responseBody = getResponseBody("/elements/count/density/groupBy/type?"
-        + "bboxes=8.694322,49.409853,8.694584,49.410038&keys=highway&values=pedestrian"
-        + "&types=way,relation&time=2015-01-01&format=csv");
+        + "bboxes=8.694322,49.409853,8.694584,49.410038&time=2015-01-01&format=csv"
+        + "&filter=(type:way or type:relation) and highway=pedestrian");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -783,8 +783,8 @@ public class GetControllerTest {
     final double expectedValue = 2.0;
     String responseBody = getResponseBody("/elements/count/groupBy/boundary?"
         + "bboxes=8.672445,49.418337,8.673196,49.419087|"
-        + "8.670868,49.418892,8.672188,49.419216&types=node&time=2017-05-01&keys=bicycle_parking"
-        + "&values=stands&format=csv");
+        + "8.670868,49.418892,8.672188,49.419216&time=2017-05-01&format=csv"
+        + "&filter=type:node and bycicle_parking=stands");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -800,9 +800,8 @@ public class GetControllerTest {
     // remainder , key=value 1 , ... , key=value N
     final double expectedValue = 5.0;
     String responseBody = getResponseBody("/elements/count/groupBy/boundary/groupBy/tag?"
-        + "bboxes=8.673025,49.41914,8.673931,49.419597|8.671206,49.419401,8.672215,49.41951&"
-        + "types=way,node,relation&time=2016-11-09&&groupByKey=natural&groupByValues=tree,water"
-        + "&format=csv");
+        + "bboxes=8.673025,49.41914,8.673931,49.419597|8.671206,49.419401,8.672215,49.41951"
+        + "&time=2016-11-09&&groupByKey=natural&groupByValues=tree,water&format=csv");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -816,8 +815,8 @@ public class GetControllerTest {
     // expect result to have 1 entry row, with 4 columns
     final double expectedValue = 1.0;
     String responseBody =
-        getResponseBody("/elements/count/groupBy/key?" + "bboxes=8.66841,49.40129,8.6728,49.40282&"
-            + "format=csv&groupByKeys=female,male&time=2019-01-01&types=node");
+        getResponseBody("/elements/count/groupBy/key?bboxes=8.66841,49.40129,8.6728,49.40282&"
+            + "format=csv&groupByKeys=female,male&time=2019-01-01&filter=type:node");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -831,9 +830,9 @@ public class GetControllerTest {
     // expect result to have 1 entry row, with 4 columns
     final double expectedValue = 2.0;
     String responseBody = getResponseBody(
-        "/elements/count/groupBy/tag?" + "bboxes=8.685459,49.412258,8.689724,49.412868"
+        "/elements/count/groupBy/tag?bboxes=8.685459,49.412258,8.689724,49.412868"
             + "&format=csv&groupByKey=amenity&groupByValues=bbq,cafe&time=2019-01-01&"
-            + "types=node,way");
+            + "filter=type:node or type:way");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -848,8 +847,8 @@ public class GetControllerTest {
     // type
     final double expectedValue = 2.0;
     String responseBody =
-        getResponseBody("/elements/count/groupBy/type?" + "bboxes=8.68748,49.41404,8.69094,49.41458"
-            + "&format=csv&time=2016-01-01&types=way,node&keys=amenity&values=restaurant");
+        getResponseBody("/elements/count/groupBy/type?bboxes=8.68748,49.41404,8.69094,49.41458"
+            + "&format=csv&time=2016-01-01&filter=(type:way or type:node) and amenity=restaurant");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -863,8 +862,8 @@ public class GetControllerTest {
     // expect result to have 1 entry row, with 4 columns
     final double expectedValue = 0.2;
     String responseBody = getResponseBody("/elements/count/ratio?"
-        + "bboxes=8.689317,49.395149,8.689799,49.395547&format=csv&keys=building&"
-        + "keys2=addr:housenumber&time=2018-01-01&types=way&types2=node");
+        + "bboxes=8.689317,49.395149,8.689799,49.395547&format=csv&time=2018-01-01"
+        + "&filter=building=* and type:way&filter2=type:node and addr:housenumber=*");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -879,9 +878,9 @@ public class GetControllerTest {
     // key=value , key2=value2, ratio)
     final double expectedValue = 0.6;
     String responseBody = getResponseBody(
-        "/elements/count/ratio/groupBy/boundary?" + "bboxes=8.65917,49.39534,8.66428,49.40019|"
-            + "8.65266,49.40178,8.65400,49.40237&format=csv&keys=highway&keys2=name&"
-            + "time=2018-01-01&types=way&types2=way");
+        "/elements/count/ratio/groupBy/boundary?bboxes=8.65917,49.39534,8.66428,49.40019|"
+            + "8.65266,49.40178,8.65400,49.40237&format=csv&time=2018-01-01"
+            + "&filter=highway=* and type:way&filter2=type:way and name=*");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -897,8 +896,8 @@ public class GetControllerTest {
     final double expectedValue = 44.5;
     String responseBody = getResponseBody("/elements/length/groupBy/boundary/groupBy/tag?"
         + "bboxes=bboxes=b1:8.68593,49.39461,8.68865,49.39529|b2:8.68885,49.39450,8.68994,49.39536"
-        + "&types=way&time=2017-11-25&keys=highway&groupByKey=highway&format=csv&groupByValues="
-        + "service,residential");
+        + "&time=2017-11-25&groupByKey=highway&format=csv&groupByValues=service,residential"
+        + "&filter=type:way and highway=*");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -930,8 +929,8 @@ public class GetControllerTest {
     final double expectedValue1 = 264812.41;
     final double expectedValue2 = 46838.97;
     String responseBody =
-        getResponseBody("/elements/area/density/groupBy/type?" + "bcircles=8.68250,49.39384,300"
-            + "&format=csv&keys=leisure&time=2018-01-01&types=way,relation");
+        getResponseBody("/elements/area/density/groupBy/type?bcircles=8.68250,49.39384,300"
+            + "&format=csv&time=2018-01-01&filter=leisure=* and (type:way or type:relation)");
     final List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -949,7 +948,7 @@ public class GetControllerTest {
     final double expectedValue = 14440.82;
     String responseBody = getResponseBody("/elements/area/density/groupBy/tag?"
         + "bboxes=8.68482,49.40167,8.68721,49.40267&format=csv&groupByKey=building&"
-        + "groupByValues=retail,church&time=2018-10-01&types=way");
+        + "groupByValues=retail,church&time=2018-10-01&filter=type:way");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -963,8 +962,8 @@ public class GetControllerTest {
     // expect result to have 1 entry row, with 3 columns
     final double expectedValue = 1984.58;
     String responseBody =
-        getResponseBody("/elements/area/groupBy/type?" + "bcircles=8.689054,49.402481,80&"
-            + "format=csv&keys=building&time=2018-01-01&types=way,relation");
+        getResponseBody("/elements/area/groupBy/type?bcircles=8.689054,49.402481,80&"
+            + "format=csv&time=2018-01-01&filter=highway=* and (type:way or type:relation)");
     // way in geojson.io sq meters: 23.97
     // relation in geojson.io sq meters: 5399.27; in response:6448.93; in qgis 5393.5
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
@@ -979,10 +978,9 @@ public class GetControllerTest {
   public void getElementsAreaRatioCsvTest() throws IOException {
     // expect result to have 1 entry row, with 4 columns
     final double expectedValue = 0.041629;
-    String responseBody =
-        getResponseBody("/elements/area/ratio?" + "bboxes=8.68934,49.39415,8.69654,49.39936"
-            + "&format=csv&keys=landuse&keys2=building&time=2018-01-01&"
-            + "types=way&types2=way&values=cemetery&values2=yes");
+    String responseBody = getResponseBody("/elements/area/ratio?"
+        + "bboxes=8.68934,49.39415,8.69654,49.39936&format=csv&time=2018-01-01"
+        + "&filter=type:way and landuse=cemetery&filter2=type:way and building=yes");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -996,8 +994,8 @@ public class GetControllerTest {
     // expect result to have 3 entry rows (1 row per time interval), with 3 columns
     final double expectedValue = 7.0;
     String responseBody =
-        getResponseBody("/users/count?" + "bboxes=8.69338,49.40772,8.71454,49.41251"
-            + "&format=csv&keys=shop&time=2014-01-01/2017-01-01/P1Y&types=node&values=clothes");
+        getResponseBody("/users/count?bboxes=8.69338,49.40772,8.71454,49.41251&format=csv"
+            + "&time=2014-01-01/2017-01-01/P1Y&filter=type:node and shop=clothes");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -1011,8 +1009,8 @@ public class GetControllerTest {
     // expect result to have 3 entry rows (1 row per time interval), with 3 columns
     final double expectedValue = 28.85;
     String responseBody = getResponseBody(
-        "users/count/density?" + "bcircles=8.68628,49.41117,200|8.68761,49.40819,200"
-            + "&format=csv&keys=wheelchair&time=2014-01-01/2017-01-01/P1Y&types=way&values=yes");
+        "users/count/density?bcircles=8.68628,49.41117,200|8.68761,49.40819,200"
+            + "&format=csv&time=2014-01-01/2017-01-01/P1Y&filter=type:way and wheelchair=yes");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -1025,10 +1023,9 @@ public class GetControllerTest {
   public void getUsersCountDensityGroupByTypeCsvTest() throws IOException {
     // expect result to have 3 entry rows (1 row per time interval)
     final double expectedValue = 3854.35;
-    String responseBody = getResponseBody(
-        "users/count/density/groupBy/type?" + "bboxes=8.691773,49.413804,8.692149,49.413975"
-            + "&format=csv&keys=addr:housenumber&time=2014-01-01/2017-01-01/P1Y"
-            + "&types=way,node&values=5");
+    String responseBody = getResponseBody("users/count/density/groupBy/type?"
+        + "bboxes=8.691773,49.413804,8.692149,49.413975&format=csv&time=2014-01-01/2017-01-01/P1Y"
+        + "&filter=addr:housenumber=5 and (type:way or type:node)");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -1042,9 +1039,9 @@ public class GetControllerTest {
     // expect result to have 3 entry rows (1 row per time interval)
     final double expectedValue = 2.0;
     String responseBody =
-        getResponseBody("users/count/groupBy/tag?" + "bboxes=8.691865,49.413835,8.692605,49.414756"
+        getResponseBody("users/count/groupBy/tag?bboxes=8.691865,49.413835,8.692605,49.414756"
             + "&format=csv&groupByKey=shop&time=2015-01-01/2018-01-01/P1Y"
-            + "&types=node&groupByValues=clothes,wine");
+            + "&groupByValues=clothes,wine&filter=type:node");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -1057,10 +1054,9 @@ public class GetControllerTest {
   public void getUsersCountGroupByTypeCsvTest() throws IOException {
     // expect result to have 3 entry rows (1 row per time interval)
     final double expectedValue = 1.0;
-    String responseBody =
-        getResponseBody("users/count/groupBy/type?" + "bboxes=8.700609,49.409336,8.701488,49.409591"
-            + "&format=csv&keys=addr:housenumber,addr:street&time=2010-01-01/2013-01-01/P1Y"
-            + "&types=way,node&values=,Plöck");
+    String responseBody = getResponseBody("users/count/groupBy/type?"
+        + "bboxes=8.700609,49.409336,8.701488,49.409591&format=csv&time=2010-01-01/2013-01-01/P1Y"
+        + "&filter=(type:way or type:node) and addr:housenumber=* and addr:street=Plöck");
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(3, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
@@ -1077,8 +1073,8 @@ public class GetControllerTest {
   public void getElementsCountFilterTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/count?bboxes=8.67452,49.40961,"
-            + "8.70392,49.41823&time=2015-01-01&filter=building=residential and type:way",
+        server + port + "/elements/count?bboxes=8.67452,49.40961,8.70392,49.41823"
+            + "&time=2015-01-01&filter=building=residential and type:way",
         JsonNode.class);
     assertEquals(40, response.getBody().get("result").get(0).get("value").asInt());
   }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -3,6 +3,7 @@ package org.heigit.ohsome.ohsomeapi.controller;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import java.io.IOException;
@@ -81,8 +82,8 @@ public class GetControllerTest {
   @Test
   public void getGeneralResourceWithFalseParameterTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
-    ResponseEntity<JsonNode> response =
-        restTemplate.getForEntity(server + port + "/elements/area?filterr=type:way", JsonNode.class);
+    ResponseEntity<JsonNode> response = restTemplate
+        .getForEntity(server + port + "/elements/area?filterr=type:way", JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());
   }
 

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -84,7 +84,7 @@ public class GetControllerTest {
   public void getGeneralResourceWithFalseParameterTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response =
-        restTemplate.getForEntity(server + port + "/elements/area?type=way", JsonNode.class);
+        restTemplate.getForEntity(server + port + "/elements/area?filterr=type:way", JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());
   }
 
@@ -92,7 +92,7 @@ public class GetControllerTest {
   public void getGeneralResourceWithSpecificParameterTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate
-        .getForEntity(server + port + "/elements/count/density?values2=highway", JsonNode.class);
+        .getForEntity(server + port + "/elements/count/density?filter2=highway", JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());
   }
 
@@ -140,8 +140,8 @@ public class GetControllerTest {
   public void getElementsCountTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/elements/count?bboxes=8.67452,49.40961,8.70392,49.41823&types=way&time=2015-01-01"
-        + "&keys=building&values=residential&showMetadata=true", JsonNode.class);
+        + "/elements/count?bboxes=8.67452,49.40961,8.70392,49.41823&time=2015-01-01&"
+        + "filter=type:way and building=residential", JsonNode.class);
     assertEquals(40, response.getBody().get("result").get(0).get("value").asInt());
   }
 
@@ -150,8 +150,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port + "/elements/count/groupBy/boundary?bboxes=8.70538,49.40891,8.70832,49.41155|"
-            + "8.68667,49.41353,8.68828,49.414&types=polygon&time=2017-01-01&keys=building"
-            + "&values=church&showMetadata=true",
+            + "8.68667,49.41353,8.68828,49.414&time=2017-01-01&showMetadata=true&"
+            + "filter=geometry:polygon and building=church",
         JsonNode.class);
     assertEquals(2, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -165,7 +165,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/count/groupBy/boundary/groupBy/tag?bboxes=8.68086,49.39948,8.69401,49.40609&"
-        + "types=way&time=2016-11-09&keys=building&groupByKey=building&groupByValues=yes",
+        + "time=2016-11-09&groupByKey=building&groupByValues=yes&filter=type:way and building=*",
         JsonNode.class);
     assertEquals(43, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -180,8 +180,8 @@ public class GetControllerTest {
   public void getElementsCountGroupByTypeTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/count/groupBy/type?bboxes=8.67038,49.40341,8.69197,49.40873"
-            + "&types=way,relation&time=2017-01-01&keys=building&showMetadata=true",
+        server + port + "/elements/count/groupBy/type?bboxes=8.67038,49.40341,8.69197,49.40873&"
+            + "time=2017-01-01&filter=building=* and (type:way or type:relation)",
         JsonNode.class);
     assertEquals(967,
         StreamSupport
@@ -195,8 +195,8 @@ public class GetControllerTest {
   public void getElementsCountGroupByTagTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/count/groupBy/tag?bboxes=8.67859,49.41189,8.67964,49.41263"
-            + "&types=way&time=2017-01-01&keys=building&groupByKey=building&showMetadata=true",
+        server + port + "/elements/count/groupBy/tag?bboxes=8.67859,49.41189,8.67964,49.41263&"
+            + "time=2017-01-01&groupByKey=building&filter=building=* and type:way",
         JsonNode.class);
     assertEquals(8, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -210,8 +210,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response =
         restTemplate.getForEntity(
-            server + port + "/elements/count/groupBy/key?bboxes=8.67859,49.41189,8.67964,49.41263"
-                + "&types=way&time=2012-01-01&groupByKeys=building&showMetadata=true",
+            server + port + "/elements/count/groupBy/key?bboxes=8.67859,49.41189,8.67964,49.41263&"
+                + "time=2012-01-01&groupByKeys=building&filter=type:way",
             JsonNode.class);
     assertEquals(7,
         StreamSupport
@@ -226,8 +226,9 @@ public class GetControllerTest {
     final double expectedValue = 0.153933;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/count/ratio?bboxes=8.66004,49.41184,8.68481,49.42094&types=way"
-            + "&time=2015-01-01/2019-01-01/P1Y&keys=building&types2=node&keys2=addr:housenumber",
+        server + port + "/elements/count/ratio?bboxes=8.66004,49.41184,8.68481,49.42094&time="
+            + "2015-01-01/2019-01-01/P1Y&filter=type:way and building=*&filter2=type:node and "
+            + "addr:housenumber=*",
         JsonNode.class);
     assertEquals(expectedValue,
         response.getBody().get("ratioResult").get(0).get("ratio").asDouble(),
@@ -240,8 +241,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port + "/elements/count/ratio/groupBy/boundary?bcircles=8.66906,49.4167,100|"
-            + "8.69013,49.40223,100&types=way&time=2017-09-20&keys=building"
-            + "&types2=node&keys2=addr:housenumber",
+            + "8.69013,49.40223,100&time=2017-09-20&filter=type:way and building=*&"
+            + "filter2=type:node and addr:housenumber=*",
         JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(
@@ -258,8 +259,8 @@ public class GetControllerTest {
     final double expectedValue = 3868.09;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
-        server + port + "/elements/count/density?bboxes=8.68794,49.41434,8.69021,49.41585"
-            + "&types=way&time=2017-08-11&keys=building&showMetadata=true",
+        server + port + "/elements/count/density?bboxes=8.68794,49.41434,8.69021,49.41585&"
+            + "time=2017-08-11&filter=type:way and building=*",
         JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
         expectedValue * deltaPercentage);
@@ -272,7 +273,7 @@ public class GetControllerTest {
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port
             + "/elements/count/density/groupBy/boundary?bboxes=8.68794,49.41434,8.69021,49.41585|"
-            + "8.67933,49.40505,8.6824,49.40638&types=way&time=2017-08-19&keys=building",
+            + "8.67933,49.40505,8.6824,49.40638&time=2017-08-19&filter=type:way and building=*",
         JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
@@ -287,8 +288,8 @@ public class GetControllerTest {
     final double expectedValue = 890.76;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/elements/count/density/groupBy/type?bboxes=8.68086,49.39948,8.69401,49.40609"
-        + "&types=way,node&time=2016-11-09&keys=addr:housenumber", JsonNode.class);
+        + "/elements/count/density/groupBy/type?bboxes=8.68086,49.39948,8.69401,49.40609&"
+        + "time=2016-11-09&filter=addr:housenumber=* and (type:way or type:node)", JsonNode.class);
     assertEquals(expectedValue,
         StreamSupport
             .stream(Spliterators.spliteratorUnknownSize(
@@ -303,8 +304,9 @@ public class GetControllerTest {
     final double expectedValue = 61.28;
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/elements/count/density/groupBy/tag?bboxes=8.68086,49.39948,8.69401,49.40609&types=way"
-        + "&time=2016-11-09&keys=building&groupByKey=building&groupByValues=yes", JsonNode.class);
+        + "/elements/count/density/groupBy/tag?bboxes=8.68086,49.39948,8.69401,49.40609&"
+        + "time=2016-11-09&groupByKey=building&groupByValues=yes&filter=type:way and building=*",
+        JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
@@ -319,8 +321,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/count/density/groupBy/boundary/groupBy/tag?bboxes=b1:8.68086,49.39948,8.69401,"
-        + "49.40609|b2:8.68081,49.39943,8.69408,49.40605&types=way&time=2016-11-09&keys=building&"
-        + "groupByKey=building", JsonNode.class);
+        + "49.40609|b2:8.68081,49.39943,8.69408,49.40605&time=2016-11-09&groupByKey=building&"
+        + "filter=type:way and building=*", JsonNode.class);
     assertEquals(expectedValue, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -157,7 +157,6 @@ public class PostControllerTest {
     map.add("filter", "geometry:point and building=*");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
-    System.out.println("rosariotest: " + response.getBody().get("result"));
     assertEquals(64, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -113,10 +113,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.67452,49.40961,8.70392,49.41823");
-    map.add("types", "way");
     map.add("time", "2013-01-01/2016-01-01/P1Y");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(40, StreamSupport
@@ -137,9 +135,8 @@ public class PostControllerTest {
             + "[8.67902,49.41460],[8.69009,49.41527],[8.68494,49.41951]]]}},{\"type\":\"Feature\","
             + "\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[8.68812,"
             + "49.40466],[8.68091,49.40058],[8.69121,49.40069],[8.68812,49.40466]]]}}]}");
-    map.add("types", "way");
     map.add("time", "2016-01-01");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
     map.add("format", "geojson");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/count/groupBy/boundary", map, JsonNode.class);
@@ -156,11 +153,11 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.6475,49.4002,8.7057,49.4268");
-    map.add("types", "point");
     map.add("time", "2013-01-01/2016-01-01/P1Y");
-    map.add("keys", "building");
+    map.add("filter", "geometry:point and building=*");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
+    System.out.println("rosariotest: " + response.getBody().get("result"));
     assertEquals(64, StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)
@@ -175,9 +172,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.663031,49.41513,8.663616,49.415451");
-    map.add("types", "point,line");
     map.add("time", "2018-01-01");
-    map.add("keys", "highway");
+    map.add("filter", "(geometry:point or geometry:line) and highway=*");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(5, StreamSupport
@@ -193,9 +189,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.6519,49.3758,8.721,49.4301");
-    map.add("types", "line");
     map.add("time", "2013-01-01/2016-01-01/P1Y");
-    map.add("keys", "building");
+    map.add("filter", "geometry:line and building=*");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(2, StreamSupport
@@ -211,10 +206,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.6519,49.3758,8.721,49.4301");
-    map.add("types", "polygon");
     map.add("time", "2015-01-01/2019-01-01/P1Y");
-    map.add("keys", "leisure");
-    map.add("values", "track");
+    map.add("filter", "geometry:polygon and leisure=track");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(11, StreamSupport
@@ -230,10 +223,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.6519,49.3758,8.721,49.4301");
-    map.add("types", "other");
     map.add("time", "2015-01-01/2019-01-01/P1Y");
-    map.add("keys", "type");
-    map.add("values", "restriction");
+    map.add("filter", "geometry:other and type=restriction");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(246, StreamSupport
@@ -250,9 +241,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.690314,49.409546,8.690861,49.409752");
-    map.add("types", "point,polygon");
     map.add("time", "2017-03-01");
-    map.add("keys", "building");
+    map.add("filter", "building=* and (geometry:polygon or geometry:point)");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/count/groupBy/type", map, JsonNode.class);
     assertEquals(2,
@@ -271,10 +261,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.69416,49.40969,8.71154,49.41161");
-    map.add("types", "way");
     map.add("time", "2013-01-01/2016-01-01/P1Y");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/perimeter", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -292,10 +280,8 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.67691,"
         + "49.41256,8.69304,49.42331");
-    map.add("types", "way");
     map.add("time", "2016-01-01");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -313,9 +299,8 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.67691,"
         + "49.41256,8.69304,49.42331");
-    map.add("types", "way");
     map.add("time", "2016-07-01");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
     map.add("groupByKey", "building");
     map.add("groupByValues", "residential,garage");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
@@ -337,9 +322,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way,relation");
     map.add("time", "2016-01-01");
-    map.add("keys", "building");
+    map.add("filter", "(type:way or type:relation) and building=*");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/groupBy/type", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -357,9 +341,9 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
     map.add("time", "2016-01-01");
     map.add("groupByKeys", "building,highway");
+    map.add("filter", "type:way");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/groupBy/key", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -377,9 +361,9 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
     map.add("time", "2015-01-01");
     map.add("groupByKey", "building");
+    map.add("filter", "type:way");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/groupBy/tag", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -396,11 +380,9 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
+    map.add("filter2", "type:relation and building=*");
     map.add("time", "2015-01-01");
-    map.add("types2", "relation");
-    map.add("keys2", "building");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/ratio", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -415,13 +397,9 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.67691,49.41256,"
         + "8.69304,49.42331");
-    map.add("types", "way");
-    map.add("keys", "building");
     map.add("time", "2015-01-01");
-    map.add("values", "yes");
-    map.add("types2", "relation");
-    map.add("keys2", "building");
-    map.add("values2", "yes");
+    map.add("filter", "type:way and building=yes");
+    map.add("filter2", "type:relation and building=yes");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
         server + port + "/elements/perimeter/ratio/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -440,10 +418,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.69416,49.40969,8.71154,49.41161");
-    map.add("types", "way");
     map.add("time", "2015-01-01");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/density", map, JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
@@ -456,9 +432,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way,relation");
     map.add("time", "2015-01-01");
-    map.add("keys", "building");
+    map.add("filter", "(type:way or type:relation) and building=*");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
         server + port + "/elements/perimeter/density/groupBy/type", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -476,9 +451,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
     map.add("time", "2015-01-01");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
     map.add("groupByKey", "building");
     map.add("groupByValues", "yes");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
@@ -498,10 +472,8 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.67691,49.41256,"
         + "8.69304,49.42331");
-    map.add("types", "way");
     map.add("time", "2015-01-01");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
         server + port + "/elements/perimeter/density/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -518,9 +490,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
     map.add("time", "2016-07-09");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
     map.add("groupByKey", "building");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
         server + port + "/elements/perimeter/density/groupBy/boundary/groupBy/tag", map,
@@ -543,8 +514,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.662714,49.413594,8.663337,49.414324");
-    map.add("types", "polygon");
     map.add("time", "2018-03-24");
+    map.add("filter", "geometry:polygon");
     map.add("groupByKeys", "building,landuse");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/perimeter/groupBy/key", map, JsonNode.class);
@@ -566,10 +537,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.69416,49.40969,8.71154,49.41161");
-    map.add("types", "way");
     map.add("time", "2015-01-01");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/area", map, JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
@@ -583,10 +552,8 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.67691,49.41256,"
         + "8.69304,49.42331");
-    map.add("types", "way");
     map.add("time", "2015-01-01");
-    map.add("keys", "building");
-    map.add("values", "residential");
+    map.add("filter", "type:way and building=residential");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/area/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -603,9 +570,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "b1:8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
     map.add("time", "2014-07-09");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
     map.add("groupByKey", "building");
     map.add("groupByValues", "residential,garage");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
@@ -626,9 +592,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way,relation");
     map.add("time", "2017-01-01");
-    map.add("keys", "building");
+    map.add("filter", "(type:way or type:relation) and building=*");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/area/groupBy/type", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -646,7 +611,7 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
+    map.add("filter", "type:way");
     map.add("time", "2017-01-01");
     map.add("groupByKeys", "building");
     ResponseEntity<JsonNode> response = restTemplate
@@ -666,7 +631,7 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
+    map.add("filter", "type:way");
     map.add("time", "2017-01-01");
     map.add("groupByKey", "building");
     ResponseEntity<JsonNode> response = restTemplate
@@ -685,11 +650,9 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
-    map.add("keys", "building");
     map.add("time", "2017-01-01");
-    map.add("types2", "relation");
-    map.add("keys2", "building");
+    map.add("filter", "type:way and building=*");
+    map.add("filter2", "type:relation and building=*");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/area/ratio", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -704,11 +667,9 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Neuenheim:8.67691,49.41256,8.69304,49.42331|"
         + "Weststadt:8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
-    map.add("keys", "building");
     map.add("time", "2017-01-01");
-    map.add("types2", "relation");
-    map.add("keys2", "building");
+    map.add("filter", "type:way and building=*");
+    map.add("filter2", "type:relation and building=*");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
         server + port + "/elements/area/ratio/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("groupByBoundaryResult").get(1)
@@ -721,10 +682,8 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.69416,49.40969,8.71154,49.41161");
-    map.add("types", "way");
     map.add("time", "2017-01-01");
-    map.add("keys", "building");
-    map.add("values", "yes");
+    map.add("filter", "type:way and building=yes");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/area/density", map, JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
@@ -737,15 +696,15 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.69416,49.40969,8.71154,49.41161");
-    map.add("types", "way,relation");
     map.add("time", "2017-01-01");
-    map.add("keys", "building");
+    map.add("filter", "building=* and (type:way or type:relation)");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/area/density/groupBy/type", map, JsonNode.class);
     assertEquals(expectedValue,
-        response.getBody().get("groupByResult").get(1).get("result").get(0).get("value").asDouble(),
+        response.getBody().get("groupByResult").get(2).get("result").get(0).get("value").asDouble(),
         expectedValue * deltaPercentage);
   }
+
 
   @Test
   public void elementsAreaDensityGroupByTagTest() {
@@ -753,9 +712,9 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.69416,49.40969,8.71154,49.41161");
-    map.add("types", "way");
     map.add("time", "2017-01-01");
     map.add("groupByKey", "building");
+    map.add("filter", "type:way");
     ResponseEntity<JsonNode> response = restTemplate
         .postForEntity(server + port + "/elements/area/density/groupBy/tag", map, JsonNode.class);
     assertEquals(expectedValue, StreamSupport
@@ -773,9 +732,8 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.67691,49.41256,"
         + "8.69304,49.42331");
-    map.add("types", "way");
     map.add("time", "2017-01-01");
-    map.add("keys", "building");
+    map.add("filter", "type:way and building=*");
     ResponseEntity<JsonNode> response = restTemplate.postForEntity(
         server + port + "/elements/area/density/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -789,7 +747,7 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "b1:8.68081,49.39821,8.69528,49.40687");
-    map.add("types", "way");
+    map.add("filter", "type:way");
     map.add("time", "2014-07-09");
     map.add("groupByKey", "building");
     map.add("groupByValues", "residential,garage");
@@ -814,9 +772,7 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68815,49.41964,8.68983,49.42045");
     map.add("time", "2019-01-01");
-    map.add("types", "polygon");
-    map.add("keys", "highway");
-    map.add("values", "pedestrian");
+    map.add("filter", "geometry:polygon and highway=pedestrian");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/area", map, JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("result").get(0).get("value").asDouble(),
@@ -830,12 +786,8 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.679789,49.409088,8.680535,49.40943");
     map.add("time", "2018-12-01");
-    map.add("types", "polygon");
-    map.add("types2", "polygon");
-    map.add("keys", "leisure");
-    map.add("keys2", "name");
-    map.add("values", "swimming_pool");
-    map.add("values2", "Schwimmerbecken");
+    map.add("filter", "geometry:polygon and leisure=swimming_pool");
+    map.add("filter2", "geometry:polygon and name=Schwimmerbecken");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/area/ratio", map, JsonNode.class);
     assertEquals(expectedValue,
@@ -850,7 +802,7 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "b1:8.68287,49.36967,8.68465,49.37135");
     map.add("time", "2019-01-01");
-    map.add("types", "polygon");
+    map.add("filter", "geometry:polygon");
     map.add("groupByKey", "leisure");
     map.add("groupByValues", "pitch,sports_centre");
     ResponseEntity<JsonNode> response = restTemplate
@@ -872,11 +824,9 @@ public class PostControllerTest {
     // expect result to have 1 entry rows with 2 columns
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.67508,49.37834,8.67565,49.38026");
-    map.add("types", "way");
     map.add("time", "2019-01-11");
-    map.add("keys", "railway");
-    map.add("values", "platform");
     map.add("format", "csv");
+    map.add("filter", "type:way and railway=platform");
     String responseBody = Helper.getPostResponseBody("/elements/length", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
@@ -892,11 +842,11 @@ public class PostControllerTest {
     // expect result to have 1 entry rows with 4 columns
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.687782,49.412861,8.687986,49.412945");
-    map.add("types", "way");
     map.add("time", "2017-08-04");
     map.add("groupByKey", "highway");
     map.add("groupByValues", "path,footway");
     map.add("format", "csv");
+    map.add("filter", "type:way");
     String responseBody = Helper.getPostResponseBody("/elements/length/density/groupBy/tag", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
@@ -913,14 +863,10 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes",
         "8.672343,49.413675,8.673797,49.41395|" + "8.674157,49.413455,8.67465,49.413741");
-    map.add("types", "way");
-    map.add("types2", "way");
     map.add("time", "2018-01-01");
-    map.add("keys", "highway");
-    map.add("keys2", "highway");
-    map.add("values", "unclassified");
-    map.add("values2", "service");
     map.add("format", "csv");
+    map.add("filter", "type:way and highway=unclassified");
+    map.add("filter2", "type:way and highway=service");
     String responseBody =
         Helper.getPostResponseBody("/elements/length/ratio/" + "groupBy/boundary", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
@@ -933,22 +879,22 @@ public class PostControllerTest {
 
   @Test
   public void elementsLengthGroupByTypeCsvTest() throws IOException {
-    // expect result to have 1 entry rows with 3 columns
+    // expect result to have 1 entry rows with 4 columns
     final double expectedValue = 106.16;
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.675873,49.412488,8.676082,49.412701");
-    map.add("types", "way,relation");
     map.add("time", "2018-01-01");
-    map.add("keys", "name");
     map.add("format", "csv");
+    map.add("filter", "(type:way or type:relation) and name=*");
     String responseBody = Helper.getPostResponseBody("/elements/length/groupBy/type", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(3, headers.size());
+    assertEquals(4, headers.size());
     assertEquals(expectedValue, Double.parseDouble(records.get(0).get("RELATION")),
         expectedValue * deltaPercentage);
   }
+
 
 
   @Test
@@ -957,7 +903,7 @@ public class PostControllerTest {
     final double expectedValue = 226.58;
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "b1:8.69205,49.41164,8.69319,49.41287|b2:8.66785,49.40973,8.66868,49.41176");
-    map.add("types", "line");
+    map.add("filter", "geometry:line");
     map.add("time", "2017-09-02");
     map.add("groupByKey", "highway");
     map.add("groupByValues", "path,primary,footway");
@@ -980,11 +926,9 @@ public class PostControllerTest {
     final double expectedValue = 662.23;
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.68855,49.40193,8.68979,49.40316");
-    map.add("types", "relation");
     map.add("time", "2017-01-01");
-    map.add("keys", "building");
-    map.add("values", "hospital");
     map.add("format", "csv");
+    map.add("filter", "type:relation and building=hospital");
     String responseBody = Helper.getPostResponseBody("/elements/perimeter", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
@@ -1001,12 +945,11 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "Weststadt:8.68081,49.39821,8.69528,49.40687|Neuenheim:8.676699,"
         + "49.414781,8.678003,49.415371");
-    map.add("types", "way");
     map.add("time", "2016-07-01");
-    map.add("keys", "building");
     map.add("groupByKey", "building");
     map.add("groupByValues", "house");
     map.add("format", "csv");
+    map.add("filter", "type:way and building=*");
     String responseBody =
         Helper.getPostResponseBody("/elements/perimeter/" + "groupBy/boundary/groupBy/tag", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
@@ -1023,11 +966,9 @@ public class PostControllerTest {
     final double expectedValue = 62501.18;
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bcircles", "8.67512, 49.40023,60|8.675659,49.39841,50");
-    map.add("types", "way");
     map.add("time", "2017-03-01");
-    map.add("keys", "building");
-    map.add("values", "yes");
     map.add("format", "csv");
+    map.add("filter", "type:way and building=yes");
     String responseBody =
         Helper.getPostResponseBody("/elements/perimeter/density/" + "groupBy/boundary", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
@@ -1044,7 +985,7 @@ public class PostControllerTest {
     final double expectedValue = 366.12;
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.685642,49.395621,8.687128,49.396528");
-    map.add("types", "way");
+    map.add("filter", "type:way");
     map.add("time", "2018-01-01");
     map.add("groupByKeys", "building,leisure");
     map.add("format", "csv");
@@ -1064,12 +1005,10 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes",
         "8.685642,49.396078,8.687192,49.396528|8.685744,49.395621,8.687294,49.396078");
-    map.add("types", "way");
     map.add("time", "2018-01-01");
-    map.add("keys", "leisure");
-    map.add("keys2", "leisure");
-    map.add("values2", "pitch");
     map.add("format", "csv");
+    map.add("filter", "type:way and leisure=*");
+    map.add("filter2", "leisure=pitch");
     String responseBody =
         Helper.getPostResponseBody("/elements/perimeter/ratio/" + "groupBy/boundary", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
@@ -1086,13 +1025,10 @@ public class PostControllerTest {
     final double expectedValue = 0.257533;
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bcircles", "b1:8.70167,49.38686,60|b2: 8.70231,49.38952,60");
-    map.add("types", "polygon");
-    map.add("types2", "polygon");
     map.add("time", "2018-08-09");
-    map.add("keys", "landuse");
-    map.add("keys2", "landuse");
-    map.add("values2", "meadow");
     map.add("format", "csv");
+    map.add("filter", "geometry:polygon and landuse=*");
+    map.add("filter2", "geometry:polygon and landuse=meadow");
     String responseBody = Helper.getPostResponseBody("/elements/area/ratio/groupBy/boundary", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
@@ -1109,12 +1045,11 @@ public class PostControllerTest {
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes",
         "b1:8.695003,49.399594,8.695421,49.399789|" + "b2:8.687788,49.402997,8.68856,49.403441");
-    map.add("types", "way");
     map.add("time", "2014-07-09");
-    map.add("keys", "building");
     map.add("groupByKey", "building");
     map.add("groupByValues", "garage");
     map.add("format", "csv");
+    map.add("filter", "type:way and building=*");
     String responseBody =
         Helper.getPostResponseBody("/elements/area/" + "groupBy/boundary/groupBy/tag", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
@@ -1127,18 +1062,17 @@ public class PostControllerTest {
 
   @Test
   public void elementsCountGroupByTypeSimpleFeatureCsvTest() throws IOException {
-    // expect result to have 1 entry rows with 3 columns
+    // expect result to have 1 entry rows with 4 columns
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bboxes", "8.688517,49.401936,8.68981,49.403168");
-    map.add("types", "line,polygon");
     map.add("time", "2019-01-01");
-    map.add("keys", "wheelchair");
     map.add("format", "csv");
+    map.add("filter", "(geometry:line or geometry:polygon) and wheelchair=*");
     String responseBody = Helper.getPostResponseBody("/elements/count/groupBy/type", map);
     List<CSVRecord> records = Helper.getCsvRecords(responseBody);
     assertEquals(1, Helper.getCsvRecords(responseBody).size());
     Map<String, Integer> headers = Helper.getCsvHeaders(responseBody);
-    assertEquals(3, headers.size());
+    assertEquals(4, headers.size());
     assertEquals(1.0, Double.parseDouble(records.get(0).get("RELATION")), 0.0);
     assertEquals(1.0, Double.parseDouble(records.get(0).get("WAY")), 0.0);
   }


### PR DESCRIPTION
instead of deprecated types, keys, values parameters
resolves #98 

- [x] needs #99 to be fixed before
- [x] likely needs #97 to be fixed as well
- [x] update GetControllerTest class
- [x] update PostControllerTest class
- [x] update DataExtractionTest class