### PR TITLE
drop unused constants, fix syntax error in filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,16 @@ Changelog
 
 ## 1.4.0-SNAPSHOT (current master)
 
+### Bug Fixes
+
+* fix some invalid filters in the default swagger examples ([#111])
+
+[#111]: https://github.com/GIScience/ohsome-api/issues/111
+
 
 ## 1.3.2
+
+### Bug Fixes
 
 * update OSHDB to 0.6.3 to fix a bug where certain invalid multipolygons cause an infinite loop ([OSHDB#343])
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
@@ -5,13 +5,11 @@ public class DefaultSwaggerParameters {
 
   public static final String BBOX = "8.625,49.3711,8.7334,49.4397";
   public static final String HIGHWAY_KEY = "highway";
-  public static final String BUILDING_KEY = "building";
-  public static final String HOUSENUMBER_KEY = "addr:housenumber";
   public static final String RESIDENTIAL_VALUE = "residential";
   public static final String TYPE_FILTER = "type:way";
   public static final String HIGHWAY_FILTER = "highway=residential";
   public static final String BUILDING_FILTER = "building=*";
-  public static final String HOUSENUMBER_FILTER = "type:node and \"addr:housenumber=*\"";
+  public static final String HOUSENUMBER_FILTER = "type:node and \"addr:housenumber\"=*";
   public static final String TIME = "2014-01-01/2017-01-01/P1Y";
   
   private DefaultSwaggerParameters() {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
@@ -5,7 +5,7 @@ public class DefaultSwaggerParameters {
 
   public static final String BBOX = "8.625,49.3711,8.7334,49.4397";
   public static final String HIGHWAY_KEY = "highway";
-  public static final String RESIDENTIAL_VALUE = "residential";
+  public static final String BUILDING_KEY = "building";
   public static final String TYPE_FILTER = "type:way";
   public static final String HIGHWAY_FILTER = "highway=residential";
   public static final String BUILDING_FILTER = "building=*";


### PR DESCRIPTION
### Description
Fixes a syntax error in one of the default filter examples in swagger.

### Corresponding issue
Closes #111

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit and API tests~~
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~