### PR TITLE
Fix slow ratio requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,18 @@ Changelog
 
 ## 1.4.0-SNAPSHOT (current master)
 
-
 ### Bug Fixes
 
 * update all tests using the filter parameter instead of deprecated types, keys, values ([#98])
 * fix some invalid filters in the default swagger examples ([#111])
 
+### Performance and Code Quality
+
+* improve performance of ratio requests ([#114])
+
 [#98]: https://github.com/GIScience/ohsome-api/issues/98
 [#111]: https://github.com/GIScience/ohsome-api/issues/111
+[#114]: https://github.com/GIScience/ohsome-api/pull/114
 
 
 ## 1.3.2

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -685,8 +685,7 @@ public class ElementsRequestExecutor {
         new InputProcessor(servletRequest, isSnapshot, isDensity);
     inputProcessorCombined.setProcessingData(processingDataCombined);
     MapReducer<OSMEntitySnapshot> mapRed = inputProcessorCombined.processParameters();
-
-    mapRed = exeUtils.newSnapshotFilter(mapRed, filterExpr1, filterExpr2);
+    mapRed = mapRed.filter(combinedFilter);
     var preResult = mapRed.aggregateByTimestamp().aggregateBy(snapshot -> {
       OSMEntity entity = snapshot.getEntity();
       boolean matches1 = filterExpr1.applyOSMGeometry(entity, snapshot.getGeometry());
@@ -996,7 +995,7 @@ public class ElementsRequestExecutor {
     Map<Integer, P> geoms =
         arrGeoms.stream().collect(Collectors.toMap(arrGeoms::indexOf, geom -> (P) geom));
     var mapRed2 = mapRed.aggregateByTimestamp().aggregateByGeometry(geoms);
-    mapRed2 = exeUtils.newSnapshotFilter(mapRed2, filterExpr1, filterExpr2);
+    mapRed2 = mapRed2.filter(combinedFilter);
     var preResult =
         mapRed2.aggregateBy((SerializableFunction<OSMEntitySnapshot, MatchType>) snapshot -> {
           OSMEntity entity = snapshot.getEntity();

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -132,31 +132,6 @@ public class ExecutionUtils {
             || snapshotMatches(snapshot, osmTypes2, simpleFeatureTypes2, keysInt2, valuesInt2));
   }
 
-  /** Applies a filter on the given MapReducer object using the given filter expressions. */
-  public MapReducer<OSMEntitySnapshot> newSnapshotFilter(MapReducer<OSMEntitySnapshot> mapRed,
-      FilterExpression filterExpr1, FilterExpression filterExpr2) {
-    return mapRed.filter(snapshot -> {
-      OSMEntity entity = snapshot.getEntity();
-      return filterExpr1.applyOSMGeometry(entity, snapshot::getGeometry)
-          || filterExpr2.applyOSMGeometry(entity, snapshot::getGeometry);
-    });
-  }
-
-  /**
-   * Applies a filter on the given MapReducer object using the given filter expressions. Used in
-   * /ratio/groupBy/boundary requests.
-   */
-  public MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot>
-      newSnapshotFilter(
-      MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot> mapRed,
-      FilterExpression filterExpr1, FilterExpression filterExpr2) {
-    return mapRed.filter(snapshot -> {
-      OSMEntity entity = snapshot.getEntity();
-      return filterExpr1.applyOSMGeometry(entity, snapshot::getGeometry)
-          || filterExpr2.applyOSMGeometry(entity, snapshot::getGeometry);
-    });
-  }
-
   /** Compares the type(s) and tag(s) of the given snapshot to the given types|tags. */
   public boolean snapshotMatches(OSMEntitySnapshot snapshot, Set<OSMType> osmTypes,
       Set<SimpleFeatureType> simpleFeatureTypes, Integer[] keysInt, Integer[] valuesInt) {


### PR DESCRIPTION
Ratio request were very slow in comparison to count requests.
This PR fix this issue.

### Description
change how filters were applied, so that filters are used as early as possible.