### PR TITLE
tweak default swagger filter parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,20 @@ Changelog
 
 ### Bug Fixes
 
-* update all tests using the filter parameter instead of deprecated types, keys, values ([#98])
 * fix some invalid filters in the default swagger examples ([#111])
 
 ### Performance and Code Quality
 
 * improve performance of ratio requests ([#114])
 
+### Other Changes
+
+* update all tests using the filter parameter instead of deprecated types, keys, values ([#98])
+* update some default parameter values in swagger UI to slightly more sensible examples ([#113])
+
 [#98]: https://github.com/GIScience/ohsome-api/issues/98
 [#111]: https://github.com/GIScience/ohsome-api/issues/111
+[#113]: https://github.com/GIScience/ohsome-api/issues/113
 [#114]: https://github.com/GIScience/ohsome-api/pull/114
 
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/config/SwaggerConfig.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/config/SwaggerConfig.java
@@ -201,7 +201,7 @@ public class SwaggerConfig implements SwaggerResourcesProvider {
     globalOperationParams
         .add(new ParameterBuilder().name("filter").description(ParameterDescriptions.FILTER)
             .modelRef(new ModelRef(string)).parameterType(query)
-            .defaultValue(DefaultSwaggerParameters.TYPE_FILTER).required(false).build());
+            .defaultValue(DefaultSwaggerParameters.GENERIC_FILTER).required(false).build());
     globalOperationParams.add(new ParameterBuilder().name("timeout")
         .description(ParameterDescriptions.TIMEOUT).modelRef(new ModelRef(string))
         .parameterType(query).defaultValue("").required(false).build());

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
@@ -6,9 +6,11 @@ public class DefaultSwaggerParameters {
   public static final String BBOX = "8.625,49.3711,8.7334,49.4397";
   public static final String HIGHWAY_KEY = "highway";
   public static final String BUILDING_KEY = "building";
-  public static final String TYPE_FILTER = "type:way";
-  public static final String HIGHWAY_FILTER = "highway=residential";
-  public static final String BUILDING_FILTER = "building=*";
+  public static final String GENERIC_FILTER = "type:way and natural=*";
+  public static final String HIGHWAY_FILTER = "type:way and highway=residential";
+  public static final String HIGHWAY_FILTER2 = "type:way and highway=*";
+  public static final String BUILDING_FILTER = "geometry:polygon and building=*";
+  public static final String BUILDING_FILTER2 = "geometry:polygon and building=house";
   public static final String HOUSENUMBER_FILTER = "type:node and \"addr:housenumber\"=*";
   public static final String TIME = "2014-01-01/2017-01-01/P1Y";
   

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/DefaultSwaggerParameters.java
@@ -3,7 +3,7 @@ package org.heigit.ohsome.ohsomeapi.controller;
 /** Holds the default values for the parameters to run test-requests in Swagger. */
 public class DefaultSwaggerParameters {
 
-  public static final String BBOX = "8.625,49.3711,8.7334,49.4397";
+  public static final String BBOX = "8.67,49.39,8.71,49.42";
   public static final String HIGHWAY_KEY = "highway";
   public static final String BUILDING_KEY = "building";
   public static final String GENERIC_FILTER = "type:way and natural=*";

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/AreaController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/AreaController.java
@@ -62,6 +62,9 @@ public class AreaController {
    */
   @ApiOperation(value = "Area of OSM elements grouped by the type", nickname = "areaGroupByType",
       response = GroupByResponse.class)
+  @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+      defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+      dataType = "string", required = false)
   @RequestMapping(value = "/groupBy/type", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response areaGroupByType(HttpServletRequest servletRequest,
@@ -203,6 +206,9 @@ public class AreaController {
    */
   @ApiOperation(value = "Density of OSM elements grouped by the type",
       nickname = "areaDensityGroupByType", response = GroupByResponse.class)
+  @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+      defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+      dataType = "string", required = false)
   @RequestMapping(value = "/density/groupBy/type", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response areaDensityGroupByType(HttpServletRequest servletRequest,
@@ -307,8 +313,11 @@ public class AreaController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
-          defaultValue = "type:relation and " + DefaultSwaggerParameters.BUILDING_FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER2,
           paramType = "query", dataType = "string", required = false)})
   @RequestMapping(value = "/ratio", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
@@ -338,8 +347,11 @@ public class AreaController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+          dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER2, paramType = "query",
           dataType = "string", required = false)})
   @RequestMapping(value = "/ratio/groupBy/boundary",
       method = {RequestMethod.GET, RequestMethod.POST}, produces = {"application/json", "text/csv"})

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/CountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/CountController.java
@@ -62,6 +62,9 @@ public class CountController {
    */
   @ApiOperation(value = "Count of OSM elements grouped by the type", nickname = "countGroupByType",
       response = GroupByResponse.class)
+  @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+      defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+      dataType = "string", required = false)
   @RequestMapping(value = "/groupBy/type", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response countGroupByType(HttpServletRequest servletRequest,
@@ -203,6 +206,9 @@ public class CountController {
    */
   @ApiOperation(value = "Density of OSM elements grouped by the type",
       nickname = "countDensityGroupByType", response = GroupByResponse.class)
+  @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+      defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+      dataType = "string", required = false)
   @RequestMapping(value = "density/groupBy/type", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response countDensityGroupByType(HttpServletRequest servletRequest,
@@ -306,6 +312,9 @@ public class CountController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.HOUSENUMBER_FILTER, paramType = "query",
           dataType = "string", required = false)})
@@ -337,6 +346,9 @@ public class CountController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.HOUSENUMBER_FILTER, paramType = "query",
           dataType = "string", required = false)})

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/CountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/CountController.java
@@ -346,7 +346,7 @@ public class CountController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/LengthController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/LengthController.java
@@ -305,6 +305,9 @@ public class LengthController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.HIGHWAY_FILTER2, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.HIGHWAY_FILTER, paramType = "query",
           dataType = "string", required = false)})
@@ -336,6 +339,9 @@ public class LengthController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.HIGHWAY_FILTER2, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.HIGHWAY_FILTER, paramType = "query",
           dataType = "string", required = false)})

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/PerimeterController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/PerimeterController.java
@@ -62,6 +62,9 @@ public class PerimeterController {
    */
   @ApiOperation(value = "Perimeter of OSM elements grouped by the type",
       nickname = "perimeterGroupByType", response = GroupByResponse.class)
+  @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+      defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+      dataType = "string", required = false)
   @RequestMapping(value = "/groupBy/type", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response perimeterGroupByType(HttpServletRequest servletRequest,
@@ -203,6 +206,9 @@ public class PerimeterController {
    */
   @ApiOperation(value = "Density of OSM elements grouped by the type",
       nickname = "perimeterDensityGroupByType", response = GroupByResponse.class)
+  @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+      defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+      dataType = "string", required = false)
   @RequestMapping(value = "density/groupBy/type", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response perimeterDensityGroupByType(HttpServletRequest servletRequest,
@@ -304,8 +310,11 @@ public class PerimeterController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
-          defaultValue = DefaultSwaggerParameters.TYPE_FILTER, paramType = "query",
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER2, paramType = "query",
           dataType = "string", required = false)})
   @RequestMapping(value = "/ratio", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
@@ -335,8 +344,11 @@ public class PerimeterController {
           defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
           defaultValue = "", paramType = "query", dataType = "string", required = false),
+      @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
+          dataType = "string", required = false),
       @ApiImplicitParam(name = "filter2", value = ParameterDescriptions.FILTER,
-          defaultValue = DefaultSwaggerParameters.TYPE_FILTER, paramType = "query",
+          defaultValue = DefaultSwaggerParameters.BUILDING_FILTER2, paramType = "query",
           dataType = "string", required = false)})
   @RequestMapping(value = "/ratio/groupBy/boundary",
       method = {RequestMethod.GET, RequestMethod.POST}, produces = {"application/json", "text/csv"})


### PR DESCRIPTION
### Description
* Implements suggestions from #113 (_Change default swagger parameters to faster-running examples_).
* Changes some default filters to more sensible options
  * replace overly generic `filter=type:way` with `type:way and natural=*`
  * query `groupBy/type` resources with a filter which can produce more than one OSM type (instead of `type:way`)

### Corresponding issue
Closes #113 

### Todo

check (performance) of these:

* [x] `GET elements/area/ratio/groupBy/boundary` → 8.21s
* [x] `POST elements/area/ratio/groupBy/boundary` → 7.61s
* [x] `GET elements/length/ratio/groupBy/boundary` → 2.01s
* [x] `POST elements/length/ratio/groupBy/boundary` → 1.92s
* [x] `GET elements/perimeter/ratio/groupBy/boundary` → 7.65s
* [x] `POST elements/perimeter/ratio/groupBy/boundary` → 7.35s
* [x] `GET elements/bbox` → ~59.27s~ 2.71s (in a second run)
* [x] `POST elements/bbox` → 2.77s
* [x] `GET elements/centroid` → 2.88s
* [x] `POST elements/centroid` → 2.63s
* [x] `GET elements/geometry` → 2.81s
* [x] `POST elements/geometry` → 2.70s
* [x] `GET elementsFullHistory/bbox` → 7.59s
* [x] `POST elementsFullHistory/bbox` → 4.58s
* [x] `GET elementsFullHistory/centroid` → 4.66s
* [x] `POST elementsFullHistory/centroid` → 4.73s
* [x] `GET elementsFullHistory/geometry` → 4.70s
* [x] `POST elementsFullHistory/geometry` → 4.57s

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- ~~I have added sufficient unit and API tests~~
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).