### PR TITLE
enable null geometries for deletions in /contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### Bug Fixes
 
 * fix some invalid filters in the default swagger examples ([#111])
-* fix returning invalid GeoJSON using empty coordinates for deletion contributions ([#129])
+* fix returning invalid GeoJSON using empty coordinates for deletion contributions ([#129], [#131])
 
 ### Performance and Code Quality
 
@@ -22,6 +22,7 @@ Changelog
 [#113]: https://github.com/GIScience/ohsome-api/issues/113
 [#114]: https://github.com/GIScience/ohsome-api/pull/114
 [#129]: https://github.com/GIScience/ohsome-api/issues/129
+[#131]: https://github.com/GIScience/ohsome-api/issues/131
 
 
 ## 1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Bug Fixes
 
 * fix some invalid filters in the default swagger examples ([#111])
+* fix returning invalid GeoJSON using empty coordinates for deletion contributions ([#129])
 
 ### Performance and Code Quality
 
@@ -20,6 +21,7 @@ Changelog
 [#111]: https://github.com/GIScience/ohsome-api/issues/111
 [#113]: https://github.com/GIScience/ohsome-api/issues/113
 [#114]: https://github.com/GIScience/ohsome-api/pull/114
+[#129]: https://github.com/GIScience/ohsome-api/issues/129
 
 
 ## 1.3.2

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1708,10 +1708,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           }
         }, {
           "type" : "Feature",
-          "geometry" : {
-            "type" : "Polygon",
-            "coordinates" : [ ]
-          },
+          "geometry" : null,
           "properties" : {
             "@changesetId" : 51902131,
             "@deletion" : "true",
@@ -1759,10 +1756,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           }
         }, {
           "type" : "Feature",
-          "geometry" : {
-            "type" : "Polygon",
-            "coordinates" : [ ]
-          },
+          "geometry" : null,
           "properties" : {
             "@changesetId" : 51902131,
             "@deletion" : "true",
@@ -1810,10 +1804,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           }
         }, {
           "type" : "Feature",
-          "geometry" : {
-            "type" : "Polygon",
-            "coordinates" : [ ]
-          },
+          "geometry" : null,
           "properties" : {
             "@changesetId" : 51902131,
             "@deletion" : "true",
@@ -1861,10 +1852,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           }
         }, {
           "type" : "Feature",
-          "geometry" : {
-            "type" : "Polygon",
-            "coordinates" : [ ]
-          },
+          "geometry" : null,
           "properties" : {
             "@changesetId" : 51902131,
             "@deletion" : "true",

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -1,6 +1,5 @@
 package org.heigit.ohsome.ohsomeapi.executor;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -61,7 +60,6 @@ import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTag;
 import org.heigit.bigspatialdata.oshdb.util.tagtranslator.TagTranslator;
 import org.heigit.bigspatialdata.oshdb.util.time.TimestampFormatter;
-import org.heigit.ohsome.filter.FilterExpression;
 import org.heigit.ohsome.ohsomeapi.Application;
 import org.heigit.ohsome.ohsomeapi.controller.rawdata.ElementsGeometry;
 import org.heigit.ohsome.ohsomeapi.exception.DatabaseAccessException;
@@ -92,9 +90,6 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Lineal;
 import org.locationtech.jts.geom.Polygonal;
 import org.locationtech.jts.geom.Puntal;
-import org.wololo.geojson.LineString;
-import org.wololo.geojson.Point;
-import org.wololo.geojson.Polygon;
 import org.wololo.jts2geojson.GeoJSONWriter;
 
 /** Holds helper methods that are used by the executor classes. */
@@ -103,9 +98,6 @@ public class ExecutionUtils {
   private AtomicReference<Boolean> isFirst;
   private final ProcessingData processingData;
   private final DecimalFormat ratioDf = defineDecimalFormat("#.######");
-  private static final Point emptyPoint = new Point(new double[0]);
-  private static final LineString emptyLine = new LineString(new double[0][0]);
-  private static final Polygon emptyPolygon = new Polygon(new double[0][0][0]);
 
   /** Applies a filter on the given MapReducer object using the given parameters. */
   public MapReducer<OSMEntitySnapshot> snapshotFilter(MapReducer<OSMEntitySnapshot> mapRed,
@@ -244,7 +236,6 @@ public class ExecutionUtils {
 
     ObjectMapper objMapper = new ObjectMapper();
     objMapper.enable(SerializationFeature.INDENT_OUTPUT);
-    objMapper.setSerializationInclusion(Include.NON_NULL);
     jsonFactory.createGenerator(tempStream, JsonEncoding.UTF8).setCodec(objMapper)
         .writeObject(osmData);
 
@@ -412,7 +403,7 @@ public class ExecutionUtils {
     switch (elemGeom) {
       case BBOX:
         if (deletionHandling) {
-          return new org.wololo.geojson.Feature(emptyPolygon, properties);
+          return new org.wololo.geojson.Feature(null, properties);
         }
         Envelope envelope = geometry.getEnvelopeInternal();
         OSHDBBoundingBox bbox = OSHDBGeometryBuilder.boundingBoxOf(envelope);
@@ -420,20 +411,20 @@ public class ExecutionUtils {
         break;
       case CENTROID:
         if (deletionHandling) {
-          return new org.wololo.geojson.Feature(emptyPoint, properties);
+          return new org.wololo.geojson.Feature(null, properties);
         }
         outputGeometry = geometry.getCentroid();
         break;
       case RAW:
       default:
         if (deletionHandling && geometry.getGeometryType().contains("Polygon")) {
-          return new org.wololo.geojson.Feature(emptyPolygon, properties);
+          return new org.wololo.geojson.Feature(null, properties);
         }
         if (deletionHandling && geometry.getGeometryType().contains("LineString")) {
-          return new org.wololo.geojson.Feature(emptyLine, properties);
+          return new org.wololo.geojson.Feature(null, properties);
         }
         if (deletionHandling && geometry.getGeometryType().contains("Point")) {
-          return new org.wololo.geojson.Feature(emptyPoint, properties);
+          return new org.wololo.geojson.Feature(null, properties);
         }
         outputGeometry = geometry;
     }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -417,13 +417,7 @@ public class ExecutionUtils {
         break;
       case RAW:
       default:
-        if (deletionHandling && geometry.getGeometryType().contains("Polygon")) {
-          return new org.wololo.geojson.Feature(null, properties);
-        }
-        if (deletionHandling && geometry.getGeometryType().contains("LineString")) {
-          return new org.wololo.geojson.Feature(null, properties);
-        }
-        if (deletionHandling && geometry.getGeometryType().contains("Point")) {
+        if (deletionHandling) {
           return new org.wololo.geojson.Feature(null, properties);
         }
         outputGeometry = geometry;

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -397,29 +397,21 @@ public class ExecutionUtils {
     }
     properties.put("@osmId", entity.getType().toString().toLowerCase() + "/" + entity.getId());
     GeoJSONWriter gjw = new GeoJSONWriter();
-    boolean deletionHandling =
-        isContributionsEndpoint && contributionTypes.contains(ContributionType.DELETION);
+    if (isContributionsEndpoint && contributionTypes.contains(ContributionType.DELETION)) {
+      return new org.wololo.geojson.Feature(null, properties);
+    }
     Geometry outputGeometry;
     switch (elemGeom) {
       case BBOX:
-        if (deletionHandling) {
-          return new org.wololo.geojson.Feature(null, properties);
-        }
         Envelope envelope = geometry.getEnvelopeInternal();
         OSHDBBoundingBox bbox = OSHDBGeometryBuilder.boundingBoxOf(envelope);
         outputGeometry = OSHDBGeometryBuilder.getGeometry(bbox);
         break;
       case CENTROID:
-        if (deletionHandling) {
-          return new org.wololo.geojson.Feature(null, properties);
-        }
         outputGeometry = geometry.getCentroid();
         break;
       case RAW:
       default:
-        if (deletionHandling) {
-          return new org.wololo.geojson.Feature(null, properties);
-        }
         outputGeometry = geometry;
     }
     return new org.wololo.geojson.Feature(gjw.write(outputGeometry), properties);

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -4,9 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.NullNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -390,8 +390,8 @@ public class DataExtractionTest {
         + "/contributions/geometry?bboxes=8.699552,49.411985,8.700909,49.412648&filter=building=* "
         + "and type:way and id:14195519&time=2008-01-28,2012-01-01&properties=metadata"
         + "&clipGeometry=false", JsonNode.class);
-    assertTrue(((ArrayNode) Helper.getFeatureByIdentifier(response, "@changesetId", "9218673")
-        .get("geometry").get("coordinates")).size() == 0);
+    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673")
+        .get("geometry").getNodeType(), JsonNodeType.NULL);
   }
 
   @Test
@@ -470,8 +470,8 @@ public class DataExtractionTest {
         + "/contributions/latest/geometry?bboxes=8.699552,49.411985,8.700909,49.412648&filter=building=* "
         + "and type:way and id:14195519&time=2008-01-28,2012-01-01&properties=metadata",
         JsonNode.class);
-    assertTrue(((ArrayNode) Helper.getFeatureByIdentifier(response, "@changesetId", "9218673")
-        .get("geometry").get("coordinates")).size() == 0);
+    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673")
+        .get("geometry").getNodeType(), JsonNodeType.NULL);
   }
 
   @Test

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -390,8 +390,8 @@ public class DataExtractionTest {
         + "/contributions/geometry?bboxes=8.699552,49.411985,8.700909,49.412648&filter=building=* "
         + "and type:way and id:14195519&time=2008-01-28,2012-01-01&properties=metadata"
         + "&clipGeometry=false", JsonNode.class);
-    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673")
-        .get("geometry").getNodeType(), JsonNodeType.NULL);
+    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673").get("geometry")
+        .getNodeType(), JsonNodeType.NULL);
   }
 
   @Test
@@ -470,8 +470,8 @@ public class DataExtractionTest {
         + "/contributions/latest/geometry?bboxes=8.699552,49.411985,8.700909,49.412648&filter=building=* "
         + "and type:way and id:14195519&time=2008-01-28,2012-01-01&properties=metadata",
         JsonNode.class);
-    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673")
-        .get("geometry").getNodeType(), JsonNodeType.NULL);
+    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673").get("geometry")
+        .getNodeType(), JsonNodeType.NULL);
   }
 
   @Test

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.NullNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -391,6 +390,17 @@ public class DataExtractionTest {
         + "and type:way and id:14195519&time=2008-01-28,2012-01-01&properties=metadata"
         + "&clipGeometry=false", JsonNode.class);
     assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "9218673").get("geometry")
+        .getNodeType(), JsonNodeType.NULL);
+  }
+
+  @Test
+  public void contributionsGeometryCollectionDeletionTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/contributions/geometry?bboxes=8.66589,49.37737,8.6688,49.37861&"
+            + "filter=id:relation/3326519&properties=tags,metadata&time=2018-01-01,2019-01-01",
+        JsonNode.class);
+    assertEquals(Helper.getFeatureByIdentifier(response, "@changesetId", "61636634").get("geometry")
         .getNodeType(), JsonNodeType.NULL);
   }
 

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/Helper.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/Helper.java
@@ -54,8 +54,8 @@ public class Helper {
    * Gets the feature from a data-extraction endpoint via the given identifier and corresponding
    * value.
    */
-  public static JsonNode getFeatureByIdentifier(ResponseEntity<JsonNode> response, String identifier,
-      String value) {
+  public static JsonNode getFeatureByIdentifier(ResponseEntity<JsonNode> response,
+      String identifier, String value) {
     return StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("features").iterator(),
             Spliterator.ORDERED), false)


### PR DESCRIPTION
### Description
use null for the geometry instead of an empty coordinate array within the response GeoJSON feature for deletions

### Corresponding issue
Closes #129

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~
- [x] I have commented my code
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~

