### PR TITLE
round output coordinates to 7 decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changelog
 * update all tests using the filter parameter instead of deprecated types, keys, values ([#98])
 * update some default parameter values in swagger UI to slightly more sensible examples ([#113])
 * restructure packages and classes within the controller and output packages ([#117])
-* limit the length of coordinates in response OSM features to 7 ([#138])
+* round coordinates of returned OSM features to 7 decimal places ([#138])
 
 [#98]: https://github.com/GIScience/ohsome-api/issues/98
 [#111]: https://github.com/GIScience/ohsome-api/issues/111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 * update all tests using the filter parameter instead of deprecated types, keys, values ([#98])
 * update some default parameter values in swagger UI to slightly more sensible examples ([#113])
 * restructure packages and classes within the controller and output packages ([#117])
+* limit the length of coordinates in response OSM features to 7 ([#138])
 
 [#98]: https://github.com/GIScience/ohsome-api/issues/98
 [#111]: https://github.com/GIScience/ohsome-api/issues/111
@@ -25,6 +26,7 @@ Changelog
 [#117]: https://github.com/GIScience/ohsome-api/issues/117
 [#129]: https://github.com/GIScience/ohsome-api/issues/129
 [#131]: https://github.com/GIScience/ohsome-api/issues/131
+[#138]: https://github.com/GIScience/ohsome-api/issues/138
 
 
 ## 1.3.2

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1350,7 +1350,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
             "type" : "Point",
             "coordinates" : [
               8.6902451,
-              49.408015899999995
+              49.4080159
             ]
           },
           "properties" : {
@@ -1426,7 +1426,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
             "type" : "Point",
             "coordinates" : [
               8.6902451,
-              49.408015899999995
+              49.4080159
             ]
           },
           "properties" : {
@@ -1502,7 +1502,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
             "type" : "Point",
             "coordinates" : [
               8.6902451,
-              49.408015899999995
+              49.4080159
             ]
           },
           "properties" : {
@@ -1578,7 +1578,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
             "type" : "Point",
             "coordinates" : [
               8.6902451,
-              49.408015899999995
+              49.4080159
             ]
           },
           "properties" : {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
@@ -120,8 +120,8 @@ public class DataRequestExecutor extends RequestExecutor {
       metadata = new Metadata(null, requestResource.getDescription(),
           inputProcessor.getRequestUrlIfGetRequest(servletRequest));
     }
-    ExtractionResponse osmData = new ExtractionResponse(ATTRIBUTION, Application.API_VERSION, metadata,
-        "FeatureCollection", Collections.emptyList());
+    ExtractionResponse osmData = new ExtractionResponse(ATTRIBUTION, Application.API_VERSION,
+        metadata, "FeatureCollection", Collections.emptyList());
     MapReducer<Feature> snapshotPreResult = null;
     if (!isContributionsEndpoint) {
       // handles cases where valid_from = t_start, valid_to = t_end; i.e. non-modified data

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -70,8 +70,8 @@ import org.heigit.ohsome.ohsomeapi.inputprocessing.SimpleFeatureType;
 import org.heigit.ohsome.ohsomeapi.oshdb.DbConnData;
 import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
 import org.heigit.ohsome.ohsomeapi.output.Attribution;
-import org.heigit.ohsome.ohsomeapi.output.ExtractionResponse;
 import org.heigit.ohsome.ohsomeapi.output.Description;
+import org.heigit.ohsome.ohsomeapi.output.ExtractionResponse;
 import org.heigit.ohsome.ohsomeapi.output.Metadata;
 import org.heigit.ohsome.ohsomeapi.output.Response;
 import org.heigit.ohsome.ohsomeapi.output.Result;
@@ -89,7 +89,9 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Lineal;
 import org.locationtech.jts.geom.Polygonal;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.Puntal;
+import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import org.wololo.jts2geojson.GeoJSONWriter;
 
 /** Holds helper methods that are used by the executor classes. */
@@ -113,8 +115,7 @@ public class ExecutionUtils {
    * Applies a filter on the given MapReducer object using the given parameters. Used in
    * /ratio/groupBy/boundary requests.
    */
-  public MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot>
-      snapshotFilter(
+  public MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot> snapshotFilter(
       MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot> mapRed,
       Set<OSMType> osmTypes1, Set<OSMType> osmTypes2, Set<SimpleFeatureType> simpleFeatureTypes1,
       Set<SimpleFeatureType> simpleFeatureTypes2, Integer[] keysInt1, Integer[] keysInt2,
@@ -195,8 +196,8 @@ public class ExecutionUtils {
    * @param <V> an arbitrary data type, used for the index'es key items
    * @return a nested data structure: for each index part there is a separate level of nested maps
    */
-  public static <A, U extends Comparable<U> & Serializable, V extends Comparable<V> & Serializable>
-      SortedMap<V, SortedMap<U, A>> nest(Map<OSHDBCombinedIndex<U, V>, A> result) {
+  public static <A, U extends Comparable<U> & Serializable, V extends Comparable<V> & Serializable> SortedMap<V, SortedMap<U, A>> nest(
+      Map<OSHDBCombinedIndex<U, V>, A> result) {
     TreeMap<V, SortedMap<U, A>> ret = new TreeMap<>();
     result.forEach((index, data) -> {
       if (!ret.containsKey(index.getSecondIndex())) {
@@ -218,16 +219,15 @@ public class ExecutionUtils {
    *         {@link com.fasterxml.jackson.core.JsonGenerator#writeObject(Object) writeObject},
    *         {@link javax.servlet.ServletResponse#getOutputStream() getOutputStream},
    *         {@link java.io.OutputStream#write(byte[]) write},
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils
-   *         #writeStreamResponse(ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils #writeStreamResponse(ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
    *         writeStreamResponse}, {@link javax.servlet.ServletOutputStream#print(String) print},
    *         and {@link javax.servlet.ServletResponse#flushBuffer() flushBuffer}
    * @throws ExecutionException thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse(
-   *         ThreadLocal, Stream, ThreadLocal, ServletOutputStream) writeStreamResponse}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse( ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
+   *         writeStreamResponse}
    * @throws InterruptedException thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse(
-   *         ThreadLocal, Stream, ThreadLocal, ServletOutputStream) writeStreamResponse}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse( ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
+   *         writeStreamResponse}
    */
   public void streamResponse(HttpServletResponse servletResponse, ExtractionResponse osmData,
       Stream<org.wololo.geojson.Feature> resultStream) throws Exception {
@@ -414,7 +414,8 @@ public class ExecutionUtils {
       default:
         outputGeometry = geometry;
     }
-    return new org.wololo.geojson.Feature(gjw.write(outputGeometry), properties);
+    return new org.wololo.geojson.Feature(gjw.write(roundCoordsOfGeomToSevenDigits(outputGeometry)),
+        properties);
   }
 
   /**
@@ -426,8 +427,7 @@ public class ExecutionUtils {
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator#sum() sum}
    */
   @SuppressWarnings({"unchecked"}) // intentionally suppressed as type format is valid
-  public <K extends Comparable<K> & Serializable, V extends Number>
-      SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, K>, V> computeResult(
+  public <K extends Comparable<K> & Serializable, V extends Number> SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, K>, V> computeResult(
       RequestResource requestResource,
       MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, K>, OSMEntitySnapshot> preResult)
       throws Exception {
@@ -461,30 +461,28 @@ public class ExecutionUtils {
    * <code>MapAggregator</code> object as input and returning a <code>SortedMap</code>.
    */
   @SuppressWarnings({"unchecked"}) // intentionally suppressed as type format is valid
-  public <K extends Comparable<K> & Serializable, V extends Number>
-      SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>
-      computeNestedResult(
+  public <K extends Comparable<K> & Serializable, V extends Number> SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V> computeNestedResult(
       RequestResource requestResource,
-      MapAggregator<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, Geometry>
-          preResult) throws Exception {
+      MapAggregator<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, Geometry> preResult)
+      throws Exception {
     switch (requestResource) {
       case COUNT:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
-            preResult.count();
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
+            .count();
       case PERIMETER:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
-            preResult.sum(geom -> {
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
+            .sum(geom -> {
               if (!(geom instanceof Polygonal)) {
                 return 0.0;
               }
               return cacheInUserData(geom, () -> Geo.lengthOf(geom.getBoundary()));
             });
       case LENGTH:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
-            preResult.sum(geom -> cacheInUserData(geom, () -> Geo.lengthOf(geom)));
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
+            .sum(geom -> cacheInUserData(geom, () -> Geo.lengthOf(geom)));
       case AREA:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
-            preResult.sum(geom -> cacheInUserData(geom, () -> Geo.areaOf(geom)));
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
+            .sum(geom -> cacheInUserData(geom, () -> Geo.areaOf(geom)));
       default:
         return null;
     }
@@ -564,8 +562,7 @@ public class ExecutionUtils {
       DecimalFormat df) {
     Double[] resultValues = new Double[resultSet.size()];
     int valueCount = 0;
-    for (Entry<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, ? extends Number> innerEntry :
-        resultSet) {
+    for (Entry<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, ? extends Number> innerEntry : resultSet) {
       resultValues[valueCount] = Double.parseDouble(df.format(innerEntry.getValue().doubleValue()));
       valueCount++;
     }
@@ -704,7 +701,7 @@ public class ExecutionUtils {
         geom = contribution.getGeometryUnclippedAfter();
       }
     }
-    return geom;
+    return roundCoordsOfGeomToSevenDigits(geom);
   }
 
   /** Combines the two given filters with an OR operation. Used in /ratio computation. */
@@ -958,6 +955,12 @@ public class ExecutionUtils {
     return properties;
   }
 
+  /** returns a new geometry out of the rounded coordinates of the given one */
+  private Geometry roundCoordsOfGeomToSevenDigits(Geometry oldGeom) {
+    PrecisionModel pm = new PrecisionModel(1E7);
+    return GeometryPrecisionReducer.reduce(oldGeom, pm);
+  }
+  
   static Set<Integer> keysToKeysInt(String[] keys, TagTranslator tt) {
     final Set<Integer> keysInt;
     if (keys.length != 0) {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ExecutionUtils.java
@@ -115,7 +115,8 @@ public class ExecutionUtils {
    * Applies a filter on the given MapReducer object using the given parameters. Used in
    * /ratio/groupBy/boundary requests.
    */
-  public MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot> snapshotFilter(
+  public MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot>
+      snapshotFilter(
       MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, OSMEntitySnapshot> mapRed,
       Set<OSMType> osmTypes1, Set<OSMType> osmTypes2, Set<SimpleFeatureType> simpleFeatureTypes1,
       Set<SimpleFeatureType> simpleFeatureTypes2, Integer[] keysInt1, Integer[] keysInt2,
@@ -196,8 +197,8 @@ public class ExecutionUtils {
    * @param <V> an arbitrary data type, used for the index'es key items
    * @return a nested data structure: for each index part there is a separate level of nested maps
    */
-  public static <A, U extends Comparable<U> & Serializable, V extends Comparable<V> & Serializable> SortedMap<V, SortedMap<U, A>> nest(
-      Map<OSHDBCombinedIndex<U, V>, A> result) {
+  public static <A, U extends Comparable<U> & Serializable, V extends Comparable<V> & Serializable>
+      SortedMap<V, SortedMap<U, A>> nest(Map<OSHDBCombinedIndex<U, V>, A> result) {
     TreeMap<V, SortedMap<U, A>> ret = new TreeMap<>();
     result.forEach((index, data) -> {
       if (!ret.containsKey(index.getSecondIndex())) {
@@ -219,15 +220,16 @@ public class ExecutionUtils {
    *         {@link com.fasterxml.jackson.core.JsonGenerator#writeObject(Object) writeObject},
    *         {@link javax.servlet.ServletResponse#getOutputStream() getOutputStream},
    *         {@link java.io.OutputStream#write(byte[]) write},
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils #writeStreamResponse(ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils
+   *         #writeStreamResponse(ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
    *         writeStreamResponse}, {@link javax.servlet.ServletOutputStream#print(String) print},
    *         and {@link javax.servlet.ServletResponse#flushBuffer() flushBuffer}
    * @throws ExecutionException thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse( ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
-   *         writeStreamResponse}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse(
+   *         ThreadLocal, Stream, ThreadLocal, ServletOutputStream) writeStreamResponse}
    * @throws InterruptedException thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse( ThreadLocal, Stream, ThreadLocal, ServletOutputStream)
-   *         writeStreamResponse}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ExecutionUtils#writeStreamResponse(
+   *         ThreadLocal, Stream, ThreadLocal, ServletOutputStream) writeStreamResponse}
    */
   public void streamResponse(HttpServletResponse servletResponse, ExtractionResponse osmData,
       Stream<org.wololo.geojson.Feature> resultStream) throws Exception {
@@ -427,7 +429,8 @@ public class ExecutionUtils {
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator#sum() sum}
    */
   @SuppressWarnings({"unchecked"}) // intentionally suppressed as type format is valid
-  public <K extends Comparable<K> & Serializable, V extends Number> SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, K>, V> computeResult(
+  public <K extends Comparable<K> & Serializable, V extends Number>
+      SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, K>, V> computeResult(
       RequestResource requestResource,
       MapAggregator<OSHDBCombinedIndex<OSHDBTimestamp, K>, OSMEntitySnapshot> preResult)
       throws Exception {
@@ -461,28 +464,30 @@ public class ExecutionUtils {
    * <code>MapAggregator</code> object as input and returning a <code>SortedMap</code>.
    */
   @SuppressWarnings({"unchecked"}) // intentionally suppressed as type format is valid
-  public <K extends Comparable<K> & Serializable, V extends Number> SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V> computeNestedResult(
+  public <K extends Comparable<K> & Serializable, V extends Number>
+      SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>
+      computeNestedResult(
       RequestResource requestResource,
-      MapAggregator<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, Geometry> preResult)
-      throws Exception {
+      MapAggregator<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, Geometry>
+          preResult) throws Exception {
     switch (requestResource) {
       case COUNT:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
-            .count();
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
+            preResult.count();
       case PERIMETER:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
-            .sum(geom -> {
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
+            preResult.sum(geom -> {
               if (!(geom instanceof Polygonal)) {
                 return 0.0;
               }
               return cacheInUserData(geom, () -> Geo.lengthOf(geom.getBoundary()));
             });
       case LENGTH:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
-            .sum(geom -> cacheInUserData(geom, () -> Geo.lengthOf(geom)));
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
+            preResult.sum(geom -> cacheInUserData(geom, () -> Geo.lengthOf(geom)));
       case AREA:
-        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>) preResult
-            .sum(geom -> cacheInUserData(geom, () -> Geo.areaOf(geom)));
+        return (SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Integer, K>, OSHDBTimestamp>, V>)
+            preResult.sum(geom -> cacheInUserData(geom, () -> Geo.areaOf(geom)));
       default:
         return null;
     }
@@ -562,7 +567,8 @@ public class ExecutionUtils {
       DecimalFormat df) {
     Double[] resultValues = new Double[resultSet.size()];
     int valueCount = 0;
-    for (Entry<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, ? extends Number> innerEntry : resultSet) {
+    for (Entry<OSHDBCombinedIndex<OSHDBTimestamp, Integer>, ? extends Number> innerEntry :
+        resultSet) {
       resultValues[valueCount] = Double.parseDouble(df.format(innerEntry.getValue().doubleValue()));
       valueCount++;
     }
@@ -701,7 +707,7 @@ public class ExecutionUtils {
         geom = contribution.getGeometryUnclippedAfter();
       }
     }
-    return roundCoordsOfGeomToSevenDigits(geom);
+    return geom;
   }
 
   /** Combines the two given filters with an OR operation. Used in /ratio computation. */

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -159,6 +159,16 @@ public class DataExtractionTest {
    */
 
   @Test
+  public void elementsGeometryCoordinateTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/elements/geometry?bboxes=8.68641,49.41642,8.69499,49.42112&filter=id:node/3429511451&"
+        + "time=2019-01-01", JsonNode.class);
+    JsonNode feature = Helper.getFeatureByIdentifier(response, "@osmId", "node/3429511451");
+    assertEquals(49.418466, feature.get("geometry").get("coordinates").get(1).asDouble(), 0);
+  }
+
+  @Test
   public void elementsFullHistoryGeometryTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
@@ -426,6 +436,16 @@ public class DataExtractionTest {
         Helper.getFeatureByIdentifier(response, "@changesetId", "7042867").get("properties");
     assertTrue(featureProperties.get("@version").asInt() == 2
         && featureProperties.get("@osmId").asText().equals("way/96054443"));
+  }
+
+  @Test
+  public void contributionsGeometryCoordinateTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/contributions/geometry?bboxes=8.68641,49.41642,8.69499,49.42112"
+        + "&filter=id:node/3429511451&time=2017-01-01,2019-01-01", JsonNode.class);
+    JsonNode feature = Helper.getFeatureByIdentifier(response, "@osmId", "node/3429511451");
+    assertEquals(49.418466, feature.get("geometry").get("coordinates").get(1).asDouble(), 0);
   }
 
   /*


### PR DESCRIPTION
### Description
limit the number of decimal values in the coordinates of response OSM features to 7

### Corresponding issue
fixes #138 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit and API tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
