### PR TITLE
apply geometry checks to all stages in elementsFullHistory requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 * fix returning invalid GeoJSON using empty coordinates for deletion contributions ([#129], [#131])
 * fix using a proper boolean data type instead of a string for contributionType in response ([#135])
 * fix NPE with createOSMFeature ([#141])
+* make sure geometry filters are applied to all returned features of elementsFullHistory requests ([#109])
 
 ### Performance and Code Quality
 
@@ -25,6 +26,7 @@ Changelog
 
 [#83]: https://github.com/GIScience/ohsome-api/issues/83
 [#98]: https://github.com/GIScience/ohsome-api/issues/98
+[#109]: https://github.com/GIScience/ohsome-api/issues/109
 [#111]: https://github.com/GIScience/ohsome-api/issues/111
 [#113]: https://github.com/GIScience/ohsome-api/issues/113
 [#114]: https://github.com/GIScience/ohsome-api/pull/114

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
@@ -29,7 +28,7 @@ public class DataExtractionTransformer implements Serializable {
   private final String startTimestamp;
   private final InputProcessingUtils utils;
   private final Set<SimpleFeatureType> simpleFeatureTypes;
-  private final Optional<FilterExpression> filter;
+  private final FilterExpression filter;
   private final Set<Integer> keysInt;
   private final boolean includeTags;
   private final boolean includeOSMMetadata;
@@ -40,7 +39,7 @@ public class DataExtractionTransformer implements Serializable {
   public DataExtractionTransformer(boolean isContributionsLatestEndpoint,
       boolean isContributionsEndpoint, ExecutionUtils exeUtils,
       boolean clipGeometries, String startTimestamp, InputProcessingUtils utils,
-      Set<SimpleFeatureType> simpleFeatureTypes, Optional<FilterExpression> filter,
+      Set<SimpleFeatureType> simpleFeatureTypes, FilterExpression filter,
       Set<Integer> keysInt, boolean includeTags, boolean includeOSMMetadata,
       ElementsGeometry elementsGeometry, String endTimestamp,
       boolean isContainingSimpleFeatureTypes) {
@@ -187,7 +186,7 @@ public class DataExtractionTransformer implements Serializable {
     if (isContainingSimpleFeatureTypes) {
       return utils.checkGeometryOnSimpleFeatures(currentGeom, simpleFeatureTypes);
     } else {
-      return filter.map(f -> f.applyOSMGeometry(currentEntity, currentGeom)).orElse(true);
+      return filter == null || filter.applyOSMGeometry(currentEntity, currentGeom);
     }
   }
 }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
@@ -110,8 +110,8 @@ public class DataRequestExecutor extends RequestExecutor {
     final boolean isContainingSimpleFeatureTypes = processingData.isContainingSimpleFeatureTypes();
     DataExtractionTransformer dataExtractionTransformer = new DataExtractionTransformer(
         isContributionsLatestEndpoint, isContributionsEndpoint, exeUtils, clipGeometries,
-        startTimestamp, utils, simpleFeatureTypes, filter, keysInt, includeTags, includeOSMMetadata,
-        elementsGeometry, endTimestamp, isContainingSimpleFeatureTypes);
+        startTimestamp, utils, simpleFeatureTypes, filter.orElse(null), keysInt, includeTags,
+        includeOSMMetadata, elementsGeometry, endTimestamp, isContainingSimpleFeatureTypes);
     MapReducer<Feature> contributionPreResult = mapRedContributions
         .flatMap(dataExtractionTransformer::buildChangedFeatures)
         .filter(Objects::nonNull);

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
@@ -110,7 +110,7 @@ public class DataRequestExecutor extends RequestExecutor {
     final boolean isContainingSimpleFeatureTypes = processingData.isContainingSimpleFeatureTypes();
     DataExtractionTransformer dataExtractionTransformer = new DataExtractionTransformer(
         isContributionsLatestEndpoint, isContributionsEndpoint, exeUtils, clipGeometries,
-        startTimestamp, utils, simpleFeatureTypes, keysInt, includeTags, includeOSMMetadata,
+        startTimestamp, utils, simpleFeatureTypes, filter, keysInt, includeTags, includeOSMMetadata,
         elementsGeometry, endTimestamp, isContainingSimpleFeatureTypes);
     MapReducer<Feature> contributionPreResult = mapRedContributions
         .flatMap(dataExtractionTransformer::buildChangedFeatures)

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -520,6 +520,8 @@ public class DataExtractionTest {
   public void issue109Test() {
     // see https://github.com/GIScience/ohsome-api/issues/109
     TestRestTemplate restTemplate = new TestRestTemplate();
+    // this uses the centroid endpoint to make sure that geometry filters are even applied to
+    // the geometries before being transformed to, e.g., centroid points
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
         server + port
             + "/elementsFullHistory/centroid?bboxes=8.69525,49.40938,8.70461,49.41203&"

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -515,4 +515,16 @@ public class DataExtractionTest {
     assertTrue(
         response.getBody().get("features").get(0).get("properties").get("@creation").asBoolean());
   }
+
+  @Test
+  public void issue109Test() {
+    // see https://github.com/GIScience/ohsome-api/issues/109
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port
+            + "/elementsFullHistory/centroid?bboxes=8.69525,49.40938,8.70461,49.41203&"
+            + "time=2011-09-05,2011-09-06&filter=geometry:polygon and id:relation/1391838",
+        JsonNode.class);
+    assertEquals(1, response.getBody().get("features").size());
+  }
 }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -426,7 +426,7 @@ public class DataExtractionTest {
   }
 
   @Test
-  public void contributionsAssociationChangeSetIdWithOsmIdAndVersion() {
+  public void contributionsAssociationChangeSetIdWithOsmIdAndVersionTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/contributions/bbox?bboxes=8.70606,49.412150,8.70766,49.413686"

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -1238,7 +1238,7 @@ public class GetControllerTest {
   }
 
   @Test
-  public void getRequestEndsByQuestionMark() {
+  public void getRequestEndsByQuestionMarkTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response =
         restTemplate.getForEntity(server + port + "/users/count?", JsonNode.class);

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -1129,7 +1129,7 @@ public class PostControllerTest {
   }
 
   @Test
-  public void postQueryRequestEndsByQuestionMark() {
+  public void postQueryRequestEndsByQuestionMarkTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     ResponseEntity<JsonNode> response =


### PR DESCRIPTION
### Description
Updates `addEntityToOutput` method to check geometry filters not only in the deprecated "simpleFeatureTypes" code path.

### Corresponding issue
Closes #109 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
