### PR TITLE
avoid unneccessary geometry building during count/ratio requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ Changelog
 * fix wrong thrown exceptions in case of invalid `bpolys` boundary ([#214])
 * fix not thrown exception in case of `bpolys` and `bcircles` boundaries not lying completely within the underlying data-extract polygon ([#201])
 
+### Performance Improvements
+
+* avoid unneccessary geometry building for `count/ratio` requests ([#161])
+
 ### Other Changes
 
 * upgrade to OSHDB version 0.7.0 – note that oshdb database files from the previous version are not compatible with this version anymore, you have to either [redownload](https://downloads.ohsome.org/OSHDB/v0.7/) or [recreate](https://github.com/GIScience/oshdb/blob/0.7/oshdb-etl/README.md) them from scratch ([#222])
 * adapt error message for contributions extration endpoint in case of wrong `time` parameter value ([#208])
 
+[#161]: https://github.com/GIScience/ohsome-api/pull/161
 [#201]: https://github.com/GIScience/ohsome-api/issues/201
 [#208]: https://github.com/GIScience/ohsome-api/issues/208
 [#214]: https://github.com/GIScience/ohsome-api/issues/214


### PR DESCRIPTION
### Description

Improve performance of `count` queries by skipping calling `getGeometry` in the `count` code paths. This eliminates the (sometimes expensive) construction of JTS geometries in cases where it is not actually needed.

### Todo

* [x] perform some simple benchmarks to see how big of a difference this makes

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~

<!--Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.-->
