### PR TITLE
Add 'contributionTypes' property to 'properties' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,24 @@ Changelog
 
 ## 1.5.0-SNAPSHOT (current master)
 
+### New Features
+
+* add new `contributionTypes` property to `properties` parameter ([#136])
+
+### Bug Fixes
+
+
+
+### Performance and Code Quality
+
+
+
 ### Other Changes
 
 * add information regarding a potential "NaN" value for `ratio` results to docs ([#166])
 
 [#166]: https://github.com/GIScience/ohsome-api/issues/154
+[#136]: https://github.com/GIScience/ohsome-api/issues/136
 
 
 ## 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changelog
 
 * add information regarding a potential "NaN" value for `ratio` results to docs ([#166])
 
-[#166]: https://github.com/GIScience/ohsome-api/issues/154
+[#166]: https://github.com/GIScience/ohsome-api/issues/166
 [#136]: https://github.com/GIScience/ohsome-api/issues/136
 
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1517,6 +1517,13 @@ Contributions Extraction
    Get the contributions provided to the OSM data. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters.
    It uses the same ``geometryType`` options as the ``/elements`` and ``/elementsFullHistory`` endpoints.
 
+   :query time: required; must consist of two ISO-8601 conform timestrings defining a time interval; no default value
+   :query properties: specifies what properties should be included for each feature representing an OSM element: ‘tags’ and/or 'metadata’ and/or 'contributionTypes'; metadata gets also the contribution types until v2.0; multiple values can be delimited by commas; default: empty
+   :query clipGeometry:  boolean operator to specify whether the returned geometries of the features should be clipped to the query’s spatial boundary (‘true’), or not (‘false’); default: ‘true’
+   :query <other>: see above_ (except **format**)
+
+.. _above: endpoints.html#post--elements-(aggregation)
+
 **Example request**:
 
 Get the changes of pharmacies with opening hours in a certain area of Heidelberg in times of COVID-19

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1518,10 +1518,11 @@ Contributions Extraction
    It uses the same ``geometryType`` options as the ``/elements`` and ``/elementsFullHistory`` endpoints.
 
    :query time: required; must consist of two ISO-8601 conform timestrings defining a time interval; no default value
-   :query properties: specifies what properties should be included for each feature representing an OSM element: ‘tags’ and/or 'metadata’ and/or 'contributionTypes'; metadata gets also the contribution types until v2.0; multiple values can be delimited by commas; default: empty
-   :query clipGeometry:  boolean operator to specify whether the returned geometries of the features should be clipped to the query’s spatial boundary (‘true’), or not (‘false’); default: ‘true’
+   :query properties: specifies what properties should be included for each feature representing an OSM element: ‘tags’ and/or 'metadata’ and/or 'contributionTypes'; metadata gets also the contribution types until v2.0; multiple values can be delimited by commas; no default value
+   :query clipGeometry:  same as for generic-extraction_
    :query <other>: see above_ (except **format**)
 
+.. _generic-extraction: endpoints.html#post--elements-(geometryType)
 .. _above: endpoints.html#post--elements-(aggregation)
 
 **Example request**:

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -32,7 +32,8 @@ public class ParameterDescriptions {
       "Output format geojson (for /groupBy/boundary resources only), csv, or json; default: json";
   public static final String PROPERTIES =
       "List of possible property-groups added to each OSM-element: 'tags' and/or 'metadata' " +
-      "and/or 'contributionTypes' (only for Contributions Extraction); default: no property";
+      "and/or 'contributionTypes' (only for the /contributions/{geometryType} endpoints); "
+      + "default: no property";
   public static final String SHOW_METADATA = "Boolean operator 'true' or 'false'; default: 'false'";
   public static final String TIMEOUT = "Custom timeout in seconds; no default value";
   public static final String FILTER = "Combines several attributive filters, e.g. OSM type, "

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -32,7 +32,7 @@ public class ParameterDescriptions {
       "Output format geojson (for /groupBy/boundary resources only), csv, or json; default: json";
   public static final String PROPERTIES =
       "List of possible property-groups added to each OSM-element: 'tags' and/or 'metadata' " +
-      "and/or 'contributionTypes'; default: no property";
+      "and/or 'contributionTypes' (only for Contributions Extraction); default: no property";
   public static final String SHOW_METADATA = "Boolean operator 'true' or 'false'; default: 'false'";
   public static final String TIMEOUT = "Custom timeout in seconds; no default value";
   public static final String FILTER = "Combines several attributive filters, e.g. OSM type, "

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -31,8 +31,8 @@ public class ParameterDescriptions {
   public static final String FORMAT =
       "Output format geojson (for /groupBy/boundary resources only), csv, or json; default: json";
   public static final String PROPERTIES =
-      "List of possible property-groups added to each OSM-element: 'tags' and/or 'metadata'; "
-          + "default: no property";
+      "List of possible property-groups added to each OSM-element: 'tags' and/or 'metadata' " +
+      "and/or 'contributionTypes'; default: no property";
   public static final String SHOW_METADATA = "Boolean operator 'true' or 'false'; default: 'false'";
   public static final String TIMEOUT = "Custom timeout in seconds; no default value";
   public static final String FILTER = "Combines several attributive filters, e.g. OSM type, "

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -40,7 +40,7 @@ public class ExceptionMessages {
           + "and/or coarser time period.";
   public static final String PROPERTIES_PARAM =
       "The properties parameter can only contain the values 'tags' and/or 'metadata' and/or "
-          + "'unclipped'.";
+          + "'contributionTypes' and/or 'unclipped'.";
   public static final String SHOWMETADATA_PARAM = "The showMetadata parameter can only contain the "
       + "values 'true', 'yes', 'false', or 'no'.";
   public static final String TIME_FORMAT = "The provided time parameter is not ISO-8601 conform.";

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -39,8 +39,11 @@ public class ExceptionMessages {
       "The given query is too large in respect to the given timeout. Please use a smaller region "
           + "and/or coarser time period.";
   public static final String PROPERTIES_PARAM =
-      "The properties parameter can only contain the values 'tags' and/or 'metadata' and/or "
-          + "'contributionTypes' and/or 'unclipped'.";
+      "The properties parameter of this resource can only contain the values 'tags' and/or "
+          + "'metadata' and/or 'unclipped'.";
+  public static final String PROPERTIES_PARAM_CONTR =
+      "The properties parameter of this resource can only contain the values 'tags' and/or "
+          + "'metadata' and/or 'contributionTypes' and/or 'unclipped'.";
   public static final String SHOWMETADATA_PARAM = "The showMetadata parameter can only contain the "
       + "values 'true', 'yes', 'false', or 'no'.";
   public static final String TIME_FORMAT = "The provided time parameter is not ISO-8601 conform.";

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -33,16 +33,16 @@ public class DataExtractionTransformer implements Serializable {
   private final Set<Integer> keysInt;
   private final boolean includeTags;
   private final boolean includeOSMMetadata;
+  private final boolean includeContributionTypes;
   private final ElementsGeometry elementsGeometry;
   private final String endTimestamp;
   private final boolean isContainingSimpleFeatureTypes;
 
   public DataExtractionTransformer(boolean isContributionsLatestEndpoint,
-      boolean isContributionsEndpoint, ExecutionUtils exeUtils,
-      boolean clipGeometries, String startTimestamp, InputProcessingUtils utils,
-      Set<SimpleFeatureType> simpleFeatureTypes, FilterExpression filter,
-      Set<Integer> keysInt, boolean includeTags, boolean includeOSMMetadata,
-      ElementsGeometry elementsGeometry, String endTimestamp,
+      boolean isContributionsEndpoint, ExecutionUtils exeUtils, boolean clipGeometries,
+      String startTimestamp, InputProcessingUtils utils, Set<SimpleFeatureType> simpleFeatureTypes,
+      FilterExpression filter, Set<Integer> keysInt, boolean includeTags, boolean includeOSMMetadata,
+      boolean includeContributionTypes, ElementsGeometry elementsGeometry, String endTimestamp,
       boolean isContainingSimpleFeatureTypes) {
     this.isContributionsLatestEndpoint = isContributionsLatestEndpoint;
     this.isContributionsEndpoint = isContributionsEndpoint;
@@ -55,6 +55,7 @@ public class DataExtractionTransformer implements Serializable {
     this.keysInt = keysInt;
     this.includeTags = includeTags;
     this.includeOSMMetadata = includeOSMMetadata;
+    this.includeContributionTypes = includeContributionTypes;
     this.elementsGeometry = elementsGeometry;
     this.endTimestamp = endTimestamp;
     this.isContainingSimpleFeatureTypes = isContainingSimpleFeatureTypes;
@@ -104,8 +105,8 @@ public class DataExtractionTransformer implements Serializable {
               properties.put("@timestamp", validTo);
             }
             output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
-                includeTags, includeOSMMetadata, isContributionsEndpoint, elementsGeometry,
-                contribution.getContributionTypes()));
+                includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
+                elementsGeometry, contribution.getContributionTypes()));
           }
         }
         skipNext = false;
@@ -139,8 +140,8 @@ public class DataExtractionTransformer implements Serializable {
         boolean addToOutput = addEntityToOutput(currentEntity, currentGeom);
         if (addToOutput) {
           output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
-              includeTags, includeOSMMetadata, isContributionsEndpoint, elementsGeometry,
-              lastContribution.getContributionTypes()));
+              includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
+              elementsGeometry, lastContribution.getContributionTypes()));
         }
       }
     } else if (isContributionsEndpoint) {
@@ -150,7 +151,7 @@ public class DataExtractionTransformer implements Serializable {
       properties.put("@timestamp",
           TimestampFormatter.getInstance().isoDateTime(lastContribution.getTimestamp()));
       output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt, false,
-          includeOSMMetadata, isContributionsEndpoint, elementsGeometry,
+          includeOSMMetadata, includeContributionTypes, isContributionsEndpoint, elementsGeometry,
           lastContribution.getContributionTypes()));
     }
     return output;
@@ -175,8 +176,8 @@ public class DataExtractionTransformer implements Serializable {
     boolean addToOutput = addEntityToOutput(entity, geom);
     if (addToOutput) {
       return Collections.singletonList(exeUtils.createOSMFeature(entity, geom, properties,
-          keysInt, includeTags, includeOSMMetadata, isContributionsEndpoint, elementsGeometry,
-          EnumSet.noneOf(ContributionType.class)));
+          keysInt, includeTags, includeOSMMetadata, includeContributionTypes,
+          isContributionsEndpoint, elementsGeometry, EnumSet.noneOf(ContributionType.class)));
     } else {
       return Collections.emptyList();
     }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
@@ -90,6 +90,7 @@ public class DataRequestExecutor extends RequestExecutor {
     InputProcessingUtils utils = inputProcessor.getUtils();
     final boolean includeTags = inputProcessor.includeTags();
     final boolean includeOSMMetadata = inputProcessor.includeOSMMetadata();
+    final boolean includeContributionTypes = inputProcessor.includeContributionTypes();
     final boolean clipGeometries = inputProcessor.isClipGeometry();
     final boolean isContributionsLatestEndpoint =
         requestResource.equals(RequestResource.CONTRIBUTIONSLATEST);
@@ -111,7 +112,8 @@ public class DataRequestExecutor extends RequestExecutor {
     DataExtractionTransformer dataExtractionTransformer = new DataExtractionTransformer(
         isContributionsLatestEndpoint, isContributionsEndpoint, exeUtils, clipGeometries,
         startTimestamp, utils, simpleFeatureTypes, filter.orElse(null), keysInt, includeTags,
-        includeOSMMetadata, elementsGeometry, endTimestamp, isContainingSimpleFeatureTypes);
+        includeOSMMetadata, includeContributionTypes, elementsGeometry, endTimestamp,
+        isContainingSimpleFeatureTypes);
     MapReducer<Feature> contributionPreResult = mapRedContributions
         .flatMap(dataExtractionTransformer::buildChangedFeatures)
         .filter(Objects::nonNull);

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -98,7 +98,6 @@ public class ElementsRequestExecutor {
     inputProcessor.processIsUnclippedParam();
     final boolean includeTags = inputProcessor.includeTags();
     final boolean includeOSMMetadata = inputProcessor.includeOSMMetadata();
-    final boolean includeContributionTypes = inputProcessor.includeContributionTypes();
     final boolean clipGeometries = inputProcessor.isClipGeometry();
     if (DbConnData.db instanceof OSHDBIgnite) {
       // on ignite: Use AffinityCall backend, which is the only one properly supporting streaming
@@ -128,7 +127,7 @@ public class ElementsRequestExecutor {
         geom = snapshot.getGeometryUnclipped();
       }
       return exeUtils.createOSMFeature(snapshot.getEntity(), geom, properties, keysInt, includeTags,
-          includeOSMMetadata, includeContributionTypes, false, elemGeom,
+          includeOSMMetadata, false, false, elemGeom,
           EnumSet.noneOf(ContributionType.class));
     }).filter(Objects::nonNull);
     Metadata metadata = null;

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -98,6 +98,7 @@ public class ElementsRequestExecutor {
     inputProcessor.processIsUnclippedParam();
     final boolean includeTags = inputProcessor.includeTags();
     final boolean includeOSMMetadata = inputProcessor.includeOSMMetadata();
+    final boolean includeContributionTypes = inputProcessor.includeContributionTypes();
     final boolean clipGeometries = inputProcessor.isClipGeometry();
     if (DbConnData.db instanceof OSHDBIgnite) {
       // on ignite: Use AffinityCall backend, which is the only one properly supporting streaming
@@ -127,7 +128,8 @@ public class ElementsRequestExecutor {
         geom = snapshot.getGeometryUnclipped();
       }
       return exeUtils.createOSMFeature(snapshot.getEntity(), geom, properties, keysInt, includeTags,
-          includeOSMMetadata, false, elemGeom, EnumSet.noneOf(ContributionType.class));
+          includeOSMMetadata, includeContributionTypes, false, elemGeom,
+          EnumSet.noneOf(ContributionType.class));
     }).filter(Objects::nonNull);
     Metadata metadata = null;
     if (processingData.isShowMetadata()) {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -68,6 +68,7 @@ public class InputProcessor {
   private Map<String, String[]> requestParameters;
   private boolean includeTags;
   private boolean includeOSMMetadata;
+  private boolean includeContributionTypes;
   private boolean clipGeometry = true;
 
   public InputProcessor(ProcessingData processingData) {
@@ -391,8 +392,9 @@ public class InputProcessor {
   }
 
   /**
-   * Processes the properties parameter used in data-extraction ressources and sets the respective
-   * boolean values includeTags, includeOSMMetadata and unclippedGeometries.
+   * Processes the properties parameter used in data-extraction resources and sets the respective
+   * boolean values includeTags, includeOSMMetadata, includeContributionTypes and
+   * unclippedGeometries.
    * 
    * @throws BadRequestException if the properties parameter contains invalid values
    */
@@ -409,6 +411,8 @@ public class InputProcessor {
         this.includeTags = true;
       } else if ("metadata".equalsIgnoreCase(property)) {
         this.includeOSMMetadata = true;
+      } else if("contributionTypes".equalsIgnoreCase(property)) {
+        this.includeContributionTypes = true;
       } else if (oldUnclippedParameter) {
         this.clipGeometry = false;
       } else {
@@ -828,6 +832,10 @@ public class InputProcessor {
     return includeOSMMetadata;
   }
 
+  public boolean includeContributionTypes() {
+    return includeContributionTypes;
+  }
+  
   public boolean isClipGeometry() {
     return clipGeometry;
   }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -393,43 +393,31 @@ public class InputProcessor {
 
   /**
    * Processes the properties parameter used in data-extraction resources and sets the respective
-   * boolean values includeTags, includeOSMMetadata and unclippedGeometries. It sets also the
-   * boolean value includeContributionTypes for the contribution endpoints.
+   * boolean values includeTags, includeOSMMetadata, unclippedGeometries, and
+   * includeContributionTypes (only for the /contributions endpoints).
    * 
    * @throws BadRequestException if the properties parameter contains invalid values
    */
   public void processPropertiesParam() {
     String[] properties =
         splitParamOnComma(createEmptyArrayIfNull(requestParameters.get("properties")));
-    if (!RequestUtils.isContributionsExtraction(requestUrl)) {
-      for (String property : properties) {
-        @Deprecated
-        boolean oldUnclippedParameter = "unclipped".equalsIgnoreCase(property);
-        if ("tags".equalsIgnoreCase(property)) {
-          this.includeTags = true;
-        } else if ("metadata".equalsIgnoreCase(property)) {
-          this.includeOSMMetadata = true;
-        } else if (oldUnclippedParameter) {
-          this.clipGeometry = false;
-        } else {
-          throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
-        }
-      }
-    } else {
-      for (String property : properties) {
-        @Deprecated
-        boolean oldUnclippedParameter = "unclipped".equalsIgnoreCase(property);
-        if ("tags".equalsIgnoreCase(property)) {
-          this.includeTags = true;
-        } else if ("metadata".equalsIgnoreCase(property)) {
-          this.includeOSMMetadata = true;
-        } else if (oldUnclippedParameter) {
-          this.clipGeometry = false;
-        } else if ("contributionTypes".equalsIgnoreCase(property)) {
+    for (String property : properties) {
+      @Deprecated
+      boolean oldUnclippedParameter = "unclipped".equalsIgnoreCase(property);
+      if ("tags".equalsIgnoreCase(property)) {
+        this.includeTags = true;
+      } else if ("metadata".equalsIgnoreCase(property)) {
+        this.includeOSMMetadata = true;
+      } else if (oldUnclippedParameter) {
+        this.clipGeometry = false;
+      } else if (RequestUtils.isContributionsExtraction(requestUrl)) {
+        if ("contributionTypes".equalsIgnoreCase(property)) {
           this.includeContributionTypes = true;
         } else {
           throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM_CONTR);
         }
+      } else {
+        throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
       }
     }
   }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -393,30 +393,43 @@ public class InputProcessor {
 
   /**
    * Processes the properties parameter used in data-extraction resources and sets the respective
-   * boolean values includeTags, includeOSMMetadata, includeContributionTypes and
-   * unclippedGeometries.
+   * boolean values includeTags, includeOSMMetadata and unclippedGeometries. It sets also the
+   * boolean value includeContributionTypes for the contribution endpoints.
    * 
    * @throws BadRequestException if the properties parameter contains invalid values
    */
   public void processPropertiesParam() {
     String[] properties =
         splitParamOnComma(createEmptyArrayIfNull(requestParameters.get("properties")));
-    if (properties.length > 3) {
-      throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
-    }
-    for (String property : properties) {
-      @Deprecated
-      boolean oldUnclippedParameter = "unclipped".equalsIgnoreCase(property);
-      if ("tags".equalsIgnoreCase(property)) {
-        this.includeTags = true;
-      } else if ("metadata".equalsIgnoreCase(property)) {
-        this.includeOSMMetadata = true;
-      } else if("contributionTypes".equalsIgnoreCase(property)) {
-        this.includeContributionTypes = true;
-      } else if (oldUnclippedParameter) {
-        this.clipGeometry = false;
-      } else {
-        throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
+    if (!RequestUtils.isContributionsExtraction(requestUrl)) {
+      for (String property : properties) {
+        @Deprecated
+        boolean oldUnclippedParameter = "unclipped".equalsIgnoreCase(property);
+        if ("tags".equalsIgnoreCase(property)) {
+          this.includeTags = true;
+        } else if ("metadata".equalsIgnoreCase(property)) {
+          this.includeOSMMetadata = true;
+        } else if (oldUnclippedParameter) {
+          this.clipGeometry = false;
+        } else {
+          throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM);
+        }
+      }
+    } else {
+      for (String property : properties) {
+        @Deprecated
+        boolean oldUnclippedParameter = "unclipped".equalsIgnoreCase(property);
+        if ("tags".equalsIgnoreCase(property)) {
+          this.includeTags = true;
+        } else if ("metadata".equalsIgnoreCase(property)) {
+          this.includeOSMMetadata = true;
+        } else if (oldUnclippedParameter) {
+          this.clipGeometry = false;
+        } else if ("contributionTypes".equalsIgnoreCase(property)) {
+          this.includeContributionTypes = true;
+        } else {
+          throw new BadRequestException(ExceptionMessages.PROPERTIES_PARAM_CONTR);
+        }
       }
     }
   }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -132,14 +132,14 @@ public class DataExtractionTest {
   }
   
   @Test
-  public void contributionTypesValueElementsBboxTest() {
+  public void checkResponseMessageForWrongPropertiesParam() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/bbox?bboxes=8.67,49.39,8.71,49.42&clipGeometry=true&"
         + "filter=type:way and natural=*&properties=contributionTypes&time=2016-04-20,2016-04-21",
         JsonNode.class);      
     assertEquals("\"The properties parameter of this resource can only contain the values 'tags' "
-        + "and/or 'metadata' and/or 'unclipped'.\"", response.getBody().get("message").toString());
+        + "and/or 'metadata' and/or 'unclipped'.\"", response.getBody().get("message").toString());   
   }
   
   @Test

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.ohsomeapi.controller;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -446,7 +447,19 @@ public class DataExtractionTest {
         + "&filter=id:node/3429511451&time=2017-01-01,2019-01-01", JsonNode.class);
     JsonNode feature = Helper.getFeatureByIdentifier(response, "@osmId", "node/3429511451");
     assertEquals(49.418466, feature.get("geometry").get("coordinates").get(1).asDouble(), 0);
+    
   }
+    @Test
+    public void contributionTypesTest() {
+      TestRestTemplate restTemplate = new TestRestTemplate();
+      ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+          + "/contributions/bbox?bboxes=8.67,49.39,8.71,49.42&clipGeometry=true&"
+          + "filter=type:way and natural=*&properties=contributionTypes&time=2016-04-20,2016-04-21",
+          JsonNode.class);      
+      JsonNode featuresArray = response.getBody().get("features");
+      assertTrue(featuresArray.get(0).get("properties").has("@geometryChange"));
+      assertFalse(featuresArray.get(0).get("properties").has("@changesetId"));
+    }
 
   /*
    * ./contributions/latest tests

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -461,7 +461,7 @@ public class DataExtractionTest {
     
   }
     @Test
-    public void contributionTypesTest() {
+    public void contributionTypesPropertiesParameterTest() {
       TestRestTemplate restTemplate = new TestRestTemplate();
       ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
           + "/contributions/bbox?bboxes=8.67,49.39,8.71,49.42&clipGeometry=true&"

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -130,7 +130,18 @@ public class DataExtractionTest {
     assertEquals("Polygon", featureGeom.get("type").asText());
     assertEquals(5, featureGeom.get("coordinates").get(0).size());
   }
-
+  
+  @Test
+  public void contributionTypesValueElementsBboxTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/elements/bbox?bboxes=8.67,49.39,8.71,49.42&clipGeometry=true&"
+        + "filter=type:way and natural=*&properties=contributionTypes&time=2016-04-20,2016-04-21",
+        JsonNode.class);      
+    assertEquals("\"The properties parameter of this resource can only contain the values 'tags' "
+        + "and/or 'metadata' and/or 'unclipped'.\"", response.getBody().get("message").toString());
+  }
+  
   @Test
   public void elementsCentroidTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();


### PR DESCRIPTION
### Description
Add the 'contributionTypes' property to property parameter for `contribution{geometryType} `endpoints.

### Corresponding issue
Closes #136 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit and API tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)