### PR TITLE
swagger tweaks: reordering and remove deprecated parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 * properly skip `GetControllerTest` class if `port1` parameter is absent ([#164])
 * update ohsome parent module, requires maven version 3.6 or higher ([#184])
 * update documentation([#88]) ([#150]) and endpoints graph ([#158])
+* remove deprecated request parameters from swagger definition and UI ([#168])
 
 [#55]: https://github.com/GIScience/ohsome-api/issues/55
 [#88]: https://github.com/GIScience/ohsome-api/issues/88
@@ -32,6 +33,7 @@ Changelog
 [#158]: https://github.com/GIScience/ohsome-api/issues/158
 [#164]: https://github.com/GIScience/ohsome-api/pull/164
 [#166]: https://github.com/GIScience/ohsome-api/issues/166
+[#168]: https://github.com/GIScience/ohsome-api/pull/168
 [#175]: https://github.com/GIScience/ohsome-api/issues/175
 [#184]: https://github.com/GIScience/ohsome-api/pull/184
 [#191]: https://github.com/GIScience/ohsome-api/issues/191

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/config/SwaggerConfig.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/config/SwaggerConfig.java
@@ -177,15 +177,6 @@ public class SwaggerConfig implements SwaggerResourcesProvider {
     globalOperationParams.add(new ParameterBuilder().name("bpolys")
         .description(ParameterDescriptions.BPOLYS).modelRef(new ModelRef(string))
         .parameterType(query).defaultValue("").required(false).build());
-    globalOperationParams.add(new ParameterBuilder().name("types")
-        .description(ParameterDescriptions.DEPRECATED_USE_FILTER).modelRef(new ModelRef(string))
-        .allowMultiple(true).parameterType(query).defaultValue("").required(false).build());
-    globalOperationParams.add(new ParameterBuilder().name("keys")
-        .description(ParameterDescriptions.DEPRECATED_USE_FILTER).modelRef(new ModelRef(string))
-        .parameterType(query).defaultValue("").required(false).build());
-    globalOperationParams.add(new ParameterBuilder().name("values")
-        .description(ParameterDescriptions.DEPRECATED_USE_FILTER).modelRef(new ModelRef(string))
-        .parameterType(query).defaultValue("").required(false).build());
     globalOperationParams
         .add(new ParameterBuilder().name("filter").description(ParameterDescriptions.FILTER)
             .modelRef(new ModelRef(string)).parameterType(query)

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/config/SwaggerConfig.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/config/SwaggerConfig.java
@@ -83,12 +83,14 @@ public class SwaggerConfig implements SwaggerResourcesProvider {
             .basePackage("org.heigit.ohsome.ohsomeapi.controller.dataaggregation"))
         .paths(PathSelectors.any()).build().apiInfo(apiInfo()).useDefaultResponseMessages(false)
         .globalOperationParameters(defineGlobalOperationParams(false))
-        .tags(new Tag("Users Count", "Compute the count of OSM users"),
-            new Tag("Elements Area", "Compute the area of polygonal OSM elements"),
-            new Tag("Elements Length", "Compute the length of linear OSM elements"),
-            new Tag("Elements Count", "Compute the count of point/linear/polygonal OSM elements"),
-            new Tag("Elements Perimeter", "Compute the perimeter of polygonal OSM elements"),
-            new Tag("Contributions Count", "Compute the count of OSM contributions"))
+        .tags(
+            new Tag("Elements Count",
+                "Compute the count of point/linear/polygonal OSM elements", 1),
+            new Tag("Elements Length", "Compute the length of linear OSM elements", 2),
+            new Tag("Elements Area", "Compute the area of polygonal OSM elements", 3),
+            new Tag("Elements Perimeter", "Compute the perimeter of polygonal OSM elements", 4),
+            new Tag("Users Count", "Compute the count of OSM users", 5),
+            new Tag("Contributions Count", "Compute the count of OSM contributions", 6))
         .forCodeGeneration(true).globalResponseMessage(RequestMethod.GET, responseMessages)
         .globalResponseMessage(RequestMethod.POST, responseMessages);
   }
@@ -102,7 +104,7 @@ public class SwaggerConfig implements SwaggerResourcesProvider {
         .apis(
             RequestHandlerSelectors.basePackage("org.heigit.ohsome.ohsomeapi.controller.metadata"))
         .paths(PathSelectors.any()).build().apiInfo(apiInfo()).useDefaultResponseMessages(false)
-        .tags(new Tag("Metadata", "Request metadata of the underlying OSHDB"))
+        .tags(new Tag("Metadata", "Request metadata of the underlying OSHDB", 1))
         .forCodeGeneration(true).globalResponseMessage(RequestMethod.GET, responseMessages);
   }
 
@@ -116,11 +118,12 @@ public class SwaggerConfig implements SwaggerResourcesProvider {
             .basePackage("org.heigit.ohsome.ohsomeapi.controller.dataextraction"))
         .paths(PathSelectors.any()).build().apiInfo(apiInfo()).useDefaultResponseMessages(false)
         .globalOperationParameters(defineGlobalOperationParams(true))
-        .tags(new Tag("Elements Extraction", "Direct access to the OSM data"),
+        .tags(
+            new Tag("Elements Extraction", "Direct access to the OSM data", 1),
             new Tag("Full History Elements Extraction",
-                "Direct access to the full history of the OSM data"),
+                "Direct access to the full history of the OSM data", 2),
             new Tag("Contributions Extraction",
-                "Direct access to all contributions provided to the OSM data"))
+                "Direct access to all contributions provided to the OSM data", 3))
         .forCodeGeneration(true).globalResponseMessage(RequestMethod.GET, responseMessages);
   }
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -38,10 +38,6 @@ public class ParameterDescriptions {
   public static final String TIMEOUT = "Custom timeout in seconds; no default value";
   public static final String FILTER = "Combines several attributive filters, e.g. OSM type, "
       + "the geometry (simple feature) type, as well as the OSM tag; no default value";
-  public static final String DEPRECATED_USE_FILTER = "This parameter has been deprecated since "
-      + "v1.0. We encourage you to use the new parameter 'filter' instead.";
-  public static final String DEPRECATED_USE_FILTER2 = "This parameter has been deprecated since "
-      + "v1.0. We encourage you to use the new parameter 'filter2' instead.";
   public static final String CLIP_GEOMETRY = "Boolean operator to specify whether the returned "
       + "geometries of the features should be clipped to the query's spatial boundary (‘true’), "
       + "or not (‘false’); default: ‘true’";

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/AreaController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/AreaController.java
@@ -305,12 +305,6 @@ public class AreaController {
           + "filter",
       nickname = "areaRatio", response = RatioResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),
@@ -339,12 +333,6 @@ public class AreaController {
   @ApiOperation(value = "Ratio of the area of OSM elements grouped by the boundary",
       nickname = "areaRatioGroupByBoundary", response = RatioGroupByBoundaryResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/CountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/CountController.java
@@ -307,12 +307,6 @@ public class CountController {
   @ApiOperation(value = "Ratio of OSM elements satisfying filter2 within items selected by filter",
       nickname = "countRatio", response = RatioResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),
@@ -341,12 +335,6 @@ public class CountController {
   @ApiOperation(value = "Ratio of OSM elements grouped by the boundary",
       nickname = "countRatioGroupByBoundary", response = RatioGroupByBoundaryResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/LengthController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/LengthController.java
@@ -301,12 +301,6 @@ public class LengthController {
   @ApiOperation(value = "Ratio of OSM elements satisfying filter2 within items selected by filter",
       nickname = "lengthRatio", response = RatioResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.HIGHWAY_FILTER2, paramType = "query",
           dataType = "string", required = false),
@@ -335,12 +329,6 @@ public class LengthController {
   @ApiOperation(value = "Ratio of the length of OSM elements grouped by the boundary",
       nickname = "lengthRatioGroupByBoundary", response = RatioGroupByBoundaryResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.HIGHWAY_FILTER2, paramType = "query",
           dataType = "string", required = false),

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/PerimeterController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/elements/PerimeterController.java
@@ -305,12 +305,6 @@ public class PerimeterController {
   @ApiOperation(value = "Ratio of OSM elements satisfying filter2 within items selected by filter",
       nickname = "perimeterRatio", response = RatioResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),
@@ -339,12 +333,6 @@ public class PerimeterController {
   @ApiOperation(value = "Ratio of the perimeter of OSM elements grouped by the boundary",
       nickname = "perimeterRatioGroupByBoundary", response = RatioGroupByBoundaryResponse.class)
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "types2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "keys2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
-      @ApiImplicitParam(name = "values2", value = ParameterDescriptions.DEPRECATED_USE_FILTER2,
-          defaultValue = "", paramType = "query", dataType = "string", required = false),
       @ApiImplicitParam(name = "filter", value = ParameterDescriptions.FILTER,
           defaultValue = DefaultSwaggerParameters.BUILDING_FILTER, paramType = "query",
           dataType = "string", required = false),


### PR DESCRIPTION
### Description
A few changes to the swagger api playground:

* reorder "tags" in specs:
  * for aggregation resources: `count` first, then `length`, `area` and `perimeter`, then `users` and last `contributions`
  * for data extraction: `geometry`, then `elementsFullHistory/geometry`, then `contributions/geometry`
  * no change for metadata :wink: 
  * reasoning: alphabetical sorting is not the most user friendly, IMHO. I propose the following sorting: simpler, more often used resources should come first, and more complex ones later
* start phasing out deprecated types/keys/values parameters by not offering them in swagger anymore
  * reasoning: a) it makes it more evident that these parameters should not be used, b) we already have a few endpoint which do _not_ support these old deprecated filters (e.g. all `contributions` endpoints), yet swagger still shows them as apparently valid options.
* ~~make time parameter for contribution endpoint optional (fall back to full time range if not specified??) TODO: check if this is a good idea and if it even works as intended~~

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit and API tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~

