### PR TITLE
fix error message for invalid boundary parameter

### DIFF
--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -11,7 +11,7 @@ public class ExceptionMessages {
       + "input could not be parsed for the creation of the response GeoJSON.";
   public static final String BOUNDARY_PARAM_FORMAT =
       "Error in processing the boundary parameter. Please "
-          + "remember to follow the format, where you separate every coordinate with a semicolon, "
+          + "remember to follow the format, where you separate every coordinate with a comma, "
           + "each boundary object with a pipe-sign "
           + "and add optional custom ids to every first coordinate with a colon.";
   public static final String BOUNDARY_IDS_FORMAT =


### PR DESCRIPTION
### Description
Fixes a small mistake in the error message one gets when using for example the `bboxes` parameter wrongly: coordinate (values) are separated by commas (`,`), not semicolons (`;`) 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit and API tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- ~~I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)~~
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
