### PR TITLE
add info regarding "NaN" ratio to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 ## 1.5.0-SNAPSHOT (current master)
 
+### Other Changes
+
+* add information regarding a potential "NaN" value for `ratio` results to docs ([#166])
+
+[#166]: https://github.com/GIScience/ohsome-api/issues/154
+
 
 ## 1.4.1
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -237,6 +237,8 @@ What is the density of restaurants with wheelchair access in Heidelberg?
    :query types2: Deprecated! use **filter2**
    :query values2: Deprecated! see **filter2**
    
+.. note:: The result of a **ratio request** may contain the value **"NaN"**, for example when dividing `0` by `0`. 
+   
 **Example request**:
 
 How many oneway streets exist within living_street streets in Heidelberg over time? And how many of them are oneway streets?


### PR DESCRIPTION
### Description
Ratio results can contain the value `"NaN"` as a string representation. This PR adds an info regarding that to the docs.

### Corresponding issue
Closes #166 

### Checklist
~My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~
~I have commented my code~
~I have written javadoc (required for public methods)~
~I have added sufficient unit and API tests~
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~

