### PR TITLE
fix failing getMetadataTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 ### Bug Fixes
 
 * fix uncaught GeoJSON parsing exception ([#55])
+* fix a bug where `getMetadataTest` unit test fails in certain setups ([#175])
 
 ### Performance and Code Quality
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/MetadataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/MetadataRequestExecutor.java
@@ -3,6 +3,7 @@ package org.heigit.ohsome.ohsomeapi.executor;
 import javax.servlet.http.HttpServletRequest;
 import org.heigit.ohsome.ohsomeapi.Application;
 import org.heigit.ohsome.ohsomeapi.exception.BadRequestException;
+import org.heigit.ohsome.ohsomeapi.inputprocessing.ProcessingData;
 import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
 import org.heigit.ohsome.ohsomeapi.output.Attribution;
 import org.heigit.ohsome.ohsomeapi.output.metadata.ExtractRegion;
@@ -24,7 +25,7 @@ public class MetadataRequestExecutor {
     }
     return new MetadataResponse(
         new Attribution(ExtractMetadata.attributionUrl, ExtractMetadata.attributionShort),
-        Application.API_VERSION, ExtractMetadata.timeout,
+        Application.API_VERSION, ProcessingData.getTimeout(),
         new ExtractRegion(ExtractMetadata.dataPolyJson,
             new TemporalExtent(ExtractMetadata.fromTstamp, ExtractMetadata.toTstamp),
             ExtractMetadata.replicationSequenceNumber));

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/oshdb/ExtractMetadata.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/oshdb/ExtractMetadata.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.ohsomeapi.oshdb;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.heigit.ohsome.ohsomeapi.inputprocessing.ProcessingData;
 import org.locationtech.jts.geom.Geometry;
 
 /** Holds the metadata that is derived from the data-extract. */
@@ -14,7 +13,6 @@ public class ExtractMetadata {
   public static Geometry dataPoly = null;
   public static JsonNode dataPolyJson = null;
   public static int replicationSequenceNumber;
-  public static double timeout = ProcessingData.getTimeout();
 
   private ExtractMetadata() {
     throw new IllegalStateException("Utility class");


### PR DESCRIPTION
### Description
Fixes failing `getMetadataTest` by using the already existing getter method for the query timeout instead of relying on global static field initialization. This prevents a possible race-condition during application start-up (static class initializer vs. main function).

### Corresponding issue
Closes #175

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit and API tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
