### PR TITLE
add missing setting for lombok sources directory for sonarlint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <opencsv.version>4.0</opencsv.version>
     <oshdb.version>0.6.4</oshdb.version>
     <projectlombok.version>1.18.16</projectlombok.version>
+    <sonar.sources>src/main/lombok</sonar.sources>
     <springboot.version>2.0.3.RELEASE</springboot.version>
     <springfox.version>2.9.2</springfox.version>
   </properties>


### PR DESCRIPTION
fixes a missing setting in #179 to tell sonarcloud to analyze the `lombok` directory