### PR TITLE
update oqt link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ These services use the ohsome API:
 * [ohsomeHeX](https://ohsome.org/apps/osm-history-explorer/)
 * [ohsome dashboard](https://ohsome.org/apps/dashboard/)
 * [ohsome2label](https://github.com/GIScience/ohsome2label)
-* [ohsome quality analyst](https://oqt.ohsome.org/)
+* [ohsome quality analyst](https://github.com/GIScience/ohsome-quality-analyst/)
 
 This is a list of clients for the ohsome API:
    


### PR DESCRIPTION
~Wait until OQT is public. (Probably until 2021-05-19)~

### Description
Update OQT link in README to https://github.com/GIScience/ohsome-quality-analyst/