### PR TITLE
Remove the parameters @snapshotTimestamp and @lastEdit from full-history responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog
 
 * fix uncaught GeoJSON parsing exception ([#55])
 * fix a bug where `getMetadataTest` unit test fails in certain setups ([#175])
-* remove the parameters `@snapshotTimestamp` and `@lastEdit` from full-history extraction response([#191])
+* remove the parameters `@snapshotTimestamp` and `@lastEdit` from full-history extraction responses ([#191])
 
 ### Performance and Code Quality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 
 * fix uncaught GeoJSON parsing exception ([#55])
 * fix a bug where `getMetadataTest` unit test fails in certain setups ([#175])
+* remove the parameters `@snapshotTimestamp` and `@lastEdit` from full-history extraction response([#191])
 
 ### Performance and Code Quality
 
@@ -27,7 +28,7 @@ Changelog
 [#55]: https://github.com/GIScience/ohsome-api/issues/55
 [#164]: https://github.com/GIScience/ohsome-api/pull/164
 [#184]: https://github.com/GIScience/ohsome-api/pull/184
-
+[#191]: https://github.com/GIScience/ohsome-api/issues/191
 
 ## 1.4.1
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -223,17 +223,12 @@ public class DataExtractionTransformer implements Serializable {
   public List<Feature> buildUnchangedFeatures(OSMEntitySnapshot snapshot) {
     Map<String, Object> properties = new TreeMap<>();
     OSMEntity entity = snapshot.getEntity();
-    if (includeOSMMetadata) {
-      properties.put("@lastEdit", entity.getTimestamp().toString());
-    }
     Geometry geom;
     if (clipGeometries) {
       geom = snapshot.getGeometry();
     } else {
       geom = snapshot.getGeometryUnclipped();
     }
-    properties.put("@snapshotTimestamp",
-        TimestampFormatter.getInstance().isoDateTime(snapshot.getTimestamp()));
     properties.put(VALID_FROM_PROPERTY, startTimestamp);
     properties.put(VALID_TO_PROPERTY, endTimestamp);
     boolean addToOutput = addEntityToOutput(entity, geom);


### PR DESCRIPTION
### Description
Remove `@snapshotTimestamp` and `@lastEdit` from full-history responses

### Corresponding issue
Closes #191 

### Checklist
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)

