### PR TITLE
Contributions latest count endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 ### New Features
 
 * add new `contributionTypes` property to `properties` parameter ([#136])
+* add new `/contributions/latest/count` endpoint ([#174])
+* add new `contributionType` parameter for contributions aggregation ([#174])
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
 
 ### Bug Fixes
@@ -15,8 +17,6 @@ Changelog
 * remove the parameters `@snapshotTimestamp` and `@lastEdit` from full-history extraction responses ([#191])
 
 ### Performance and Code Quality
-
-
 
 ### Other Changes
 
@@ -32,17 +32,16 @@ Changelog
 [#158]: https://github.com/GIScience/ohsome-api/issues/158
 [#164]: https://github.com/GIScience/ohsome-api/pull/164
 [#166]: https://github.com/GIScience/ohsome-api/issues/166
+[#174]: https://github.com/GIScience/ohsome-api/issues/174
 [#175]: https://github.com/GIScience/ohsome-api/issues/175
 [#184]: https://github.com/GIScience/ohsome-api/pull/184
 [#191]: https://github.com/GIScience/ohsome-api/issues/191
-
 
 ## 1.4.2
 
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field (backported from 1.5.0) ([#200])
 
 [#200]: https://github.com/GIScience/ohsome-api/issues/200
-
 
 ## 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changelog
 
 [#200]: https://github.com/GIScience/ohsome-api/issues/200
 
+
 ## 1.4.1
 
 * upgrade OSHDB to version [OSHDB#0.6.4], fixes the following two bugs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,7 @@ Changelog
 * add new `contributionTypes` property to `properties` parameter ([#136])
 * add new `/contributions/latest/count` endpoint ([#174])
 * add new `contributionType` parameter for contributions aggregation ([#174])
-<<<<<<< HEAD
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
-=======
->>>>>>> 5183d086 (chore: correct changelog)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changelog
 [#184]: https://github.com/GIScience/ohsome-api/pull/184
 [#191]: https://github.com/GIScience/ohsome-api/issues/191
 
+
 ## 1.4.2
 
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field (backported from 1.5.0) ([#200])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 
 * add new `contributionTypes` property to `properties` parameter ([#136])
 * add new `/contributions/latest/count` endpoint ([#174])
+* add new `/contributions/latest/count/density` endpoint
 * add new `contributionType` parameter for contributions aggregation ([#174])
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ Changelog
 ### New Features
 
 * add new `contributionTypes` property to `properties` parameter ([#136])
-* add new `/contributions/latest/count` endpoint ([#174])
-* add new `/contributions/latest/count/density` endpoint
+* add new `/contributions/latest/count` and `/contributions/latest/count/density` endpoints ([#174])
 * add new `contributionType` parameter for contributions aggregation ([#174])
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
 
@@ -37,7 +36,6 @@ Changelog
 [#175]: https://github.com/GIScience/ohsome-api/issues/175
 [#184]: https://github.com/GIScience/ohsome-api/pull/184
 [#191]: https://github.com/GIScience/ohsome-api/issues/191
-
 
 ## 1.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ Changelog
 * add new `contributionTypes` property to `properties` parameter ([#136])
 * add new `/contributions/latest/count` endpoint ([#174])
 * add new `contributionType` parameter for contributions aggregation ([#174])
+<<<<<<< HEAD
 * contribution extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
+=======
+>>>>>>> 5183d086 (chore: correct changelog)
 
 ### Bug Fixes
 

--- a/docs/_static/ohsome-api-tree.svg
+++ b/docs/_static/ohsome-api-tree.svg
@@ -23,12 +23,26 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs852">
+    <marker
+       style="overflow:visible"
+       id="TriangleInL"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="TriangleInL"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.8)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
+         id="path1657" />
+    </marker>
     <marker
        style="overflow:visible"
        id="marker2183"
@@ -39,7 +53,7 @@
        inkscape:isstock="true">
       <path
          transform="scale(-0.8)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1pt;stroke-opacity:1"
          d="M 5.77,0 -2.88,5 V -5 Z"
          id="path2181" />
     </marker>
@@ -59,7 +73,7 @@
        inkscape:isstock="true">
       <path
          transform="scale(-0.8)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          d="M 5.77,0 -2.88,5 V -5 Z"
          id="path3869" />
     </marker>
@@ -179,6 +193,30 @@
          style="fill:#fffff7;fill-opacity:0.84;stroke-width:1.17494"
          inkscape:export-xdpi="96"
          inkscape:export-ydpi="96" />
+      <g
+         id="path1316"
+         style="opacity:1">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+           d="m 653.15039,-137.10156 -0.2832,43.962888 1.28339,0.0059 V -137.0957 Z"
+           id="path1876"
+           sodipodi:nodetypes="ccccc" />
+        <g
+           id="g1866">
+          <g
+             id="path1868"
+             style="opacity:1">
+            <path
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.799945pt;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1.0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;"
+               d="m 653.33672,-88.520745 -3.95488,-6.945254 7.99929,0.05175 z"
+               id="path1872" />
+            <path
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1.0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;"
+               d="M 648.46094 -96.005859 L 653.33008 -87.455078 L 653.79688 -88.25 L 658.30859 -95.941406 L 648.46094 -96.005859 z M 650.30273 -94.927734 L 656.45508 -94.886719 L 653.34375 -89.587891 L 650.30273 -94.927734 z "
+               id="path1874" />
+          </g>
+        </g>
+      </g>
     </g>
     <!-- https://api.ohsome.org -->
     <!-- v1 -->
@@ -1063,7 +1101,8 @@
          fill="none"
          stroke="#000000"
          d="m 83.24,-215.7 c 0,7.72 0,16.99 0,25.59"
-         id="path821" />
+         id="path821"
+         style="stroke-width:0.99993103;stroke-miterlimit:4;stroke-dasharray:none" />
       <polygon
          fill="#000000"
          stroke="#000000"
@@ -1284,7 +1323,7 @@
        id="path3107"
        style="opacity:1">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;stroke-width:0.99993103"
          d="m 504.90234,-210.35547 -1,0.0117 0.72071,56.83008 1,-0.0117 z"
          id="path2253" />
       <g
@@ -1330,7 +1369,7 @@
        id="path3403"
        style="opacity:1">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;stroke-width:0.99993103"
          d="m 84.898438,-287.46875 -1,0.01 0.273437,30.2832 1.001953,-0.008 z"
          id="path1580" />
       <g
@@ -1486,5 +1525,37 @@
         </a>
       </g>
     </g>
+    <g
+       id="node15-5-3-6"
+       class="node"
+       transform="translate(570.01211,158.12858)">
+      <title
+         id="title774-0-6-2">count</title>
+      <g
+         id="a_node15-3-7-9"
+         transform="translate(-0.00664178,2.0656655)">
+        <a
+           xlink:href="https://api.ohsome.org/v1/users/count"
+           xlink:title="count"
+           id="a780-6-5-1">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+             d="m 83.240234,-252.5 c -8.526697,0 -16.253258,2.02806 -21.884765,5.3418 -5.631508,3.31373 -9.205078,7.95803 -9.205078,13.1582 0,5.20017 3.57357,9.84447 9.205078,13.1582 5.631507,3.31374 13.358068,5.3418 21.884765,5.3418 8.526698,0 16.251305,-2.02806 21.882816,-5.3418 5.6315,-3.31373 9.20703,-7.95803 9.20703,-13.1582 0,-5.20017 -3.57553,-9.84447 -9.20703,-13.1582 -5.631511,-3.31374 -13.356118,-5.3418 -21.882816,-5.3418 z m 0,1 c 8.367693,0 15.937059,2.00214 21.376956,5.20312 5.43989,3.20099 8.71289,7.55593 8.71289,12.29688 0,4.74095 -3.273,9.09589 -8.71289,12.29688 -5.439897,3.20098 -13.009263,5.20312 -21.376956,5.20312 -8.367692,0 -15.937058,-2.00214 -21.376953,-5.20312 -5.439895,-3.20099 -8.71289,-7.55593 -8.71289,-12.29688 0,-4.74095 3.272995,-9.09589 8.71289,-12.29688 5.439895,-3.20098 13.009261,-5.20312 21.376953,-5.20312 z"
+             id="ellipse776-1-3-2" />
+          <text
+             text-anchor="middle"
+             x="83.239998"
+             y="-230.3"
+             font-family="Times, serif"
+             font-size="14px"
+             id="text778-0-5-7">count</text>
+        </a>
+      </g>
+    </g>
+    <path
+       style="fill:none;stroke:none;stroke-width:0.750136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker2183)"
+       d="m 653.2822,-97.987005 0.28443,-43.961975 z"
+       id="path1240"
+       sodipodi:nodetypes="ccc" />
   </g>
 </svg>

--- a/docs/_static/ohsome-api-tree.svg
+++ b/docs/_static/ohsome-api-tree.svg
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="718pt"
    height="345.10147pt"
    viewBox="0 0 718.13 345.10147"
    version="1.1"
    id="svg848"
    sodipodi:docname="ohsome-api-tree.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+   inkscape:version="1.1 (c4e8f9ed74, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata854">
     <rdf:RDF>
@@ -163,9 +163,9 @@
      inkscape:window-height="739"
      id="namedview850"
      showgrid="false"
-     inkscape:zoom="0.76508705"
-     inkscape:cx="480.04618"
-     inkscape:cy="171.19016"
+     inkscape:zoom="1.01"
+     inkscape:cx="293.56436"
+     inkscape:cy="253.9604"
      inkscape:window-x="1366"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -174,7 +174,9 @@
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0" />
+     fit-margin-bottom="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="pt" />
   <g
      id="graph0"
      class="graph"
@@ -193,30 +195,6 @@
          style="fill:#fffff7;fill-opacity:0.84;stroke-width:1.17494"
          inkscape:export-xdpi="96"
          inkscape:export-ydpi="96" />
-      <g
-         id="path1316"
-         style="opacity:1">
-        <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-           d="m 653.15039,-137.10156 -0.2832,43.962888 1.28339,0.0059 V -137.0957 Z"
-           id="path1876"
-           sodipodi:nodetypes="ccccc" />
-        <g
-           id="g1866">
-          <g
-             id="path1868"
-             style="opacity:1">
-            <path
-               style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.799945pt;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1.0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;"
-               d="m 653.33672,-88.520745 -3.95488,-6.945254 7.99929,0.05175 z"
-               id="path1872" />
-            <path
-               style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1.0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;"
-               d="M 648.46094 -96.005859 L 653.33008 -87.455078 L 653.79688 -88.25 L 658.30859 -95.941406 L 648.46094 -96.005859 z M 650.30273 -94.927734 L 656.45508 -94.886719 L 653.34375 -89.587891 L 650.30273 -94.927734 z "
-               id="path1874" />
-          </g>
-        </g>
-      </g>
     </g>
     <!-- https://api.ohsome.org -->
     <!-- v1 -->
@@ -839,22 +817,6 @@
          id="polygon708" />
     </g>
     <!-- density&#45;&gt;groupBy/boundary -->
-    <g
-       id="edge16"
-       class="edge">
-      <title
-         id="title711">density-&gt;groupBy/boundary</title>
-      <path
-         fill="none"
-         stroke="#000000"
-         d="m 250.52,-146.33 c 15.07,10.04 36.77,23.49 55.76,34.62"
-         id="path713" />
-      <polygon
-         fill="#000000"
-         stroke="#000000"
-         points="304.65,-108.61 308.16,-114.67 315.05,-106.63 "
-         id="polygon715" />
-    </g>
     <!-- density&#45;&gt;groupBy/boundary -->
     <g
        id="edge28"
@@ -890,22 +852,6 @@
          id="polygon729" />
     </g>
     <!-- density&#45;&gt;groupBy/tag -->
-    <g
-       id="edge29"
-       class="edge">
-      <title
-         id="title732">density-&gt;groupBy/tag</title>
-      <path
-         fill="none"
-         stroke="#000000"
-         d="m 242.95,-144.58 c 7.21,18.13 15.81,47.99 26.29,72.58 3.78,8.88 8.59,18.22 12.78,26.55"
-         id="path734" />
-      <polygon
-         fill="#000000"
-         stroke="#000000"
-         points="279,-43.66 285.28,-46.75 286.56,-36.24 "
-         id="polygon736" />
-    </g>
     <!-- density&#45;&gt;groupBy/type -->
     <g
        id="edge18"
@@ -924,39 +870,7 @@
          id="polygon743" />
     </g>
     <!-- density&#45;&gt;groupBy/type -->
-    <g
-       id="edge30"
-       class="edge">
-      <title
-         id="title746">density-&gt;groupBy/type</title>
-      <path
-         fill="none"
-         stroke="#000000"
-         d="m 216.65,-145.46 c -12.35,9.85 -29.83,22.73 -45.4,33.48"
-         id="path748" />
-      <polygon
-         fill="#000000"
-         stroke="#000000"
-         points="169.13,-114.77 173.07,-108.99 162.84,-106.25 "
-         id="polygon750" />
-    </g>
     <!-- groupBy/boundary&#45;&gt;groupBy/tag -->
-    <g
-       id="edge19"
-       class="edge">
-      <title
-         id="title753">groupBy/boundary-&gt;groupBy/tag</title>
-      <path
-         fill="none"
-         stroke="#000000"
-         d="m 326.89,-72.41 c -7.78,8.42 -16.47,18.83 -23.64,28.21"
-         id="path755" />
-      <polygon
-         fill="#000000"
-         stroke="#000000"
-         points="300.28,-46.08 305.92,-41.92 297.16,-35.96 "
-         id="polygon757" />
-    </g>
     <!-- groupBy/boundary&#45;&gt;groupBy/tag -->
     <g
        id="edge20"
@@ -1525,37 +1439,31 @@
         </a>
       </g>
     </g>
-    <g
-       id="node15-5-3-6"
-       class="node"
-       transform="translate(570.01211,158.12858)">
-      <title
-         id="title774-0-6-2">count</title>
-      <g
-         id="a_node15-3-7-9"
-         transform="translate(-0.00664178,2.0656655)">
-        <a
-           xlink:href="https://api.ohsome.org/v1/users/count"
-           xlink:title="count"
-           id="a780-6-5-1">
-          <path
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-             d="m 83.240234,-252.5 c -8.526697,0 -16.253258,2.02806 -21.884765,5.3418 -5.631508,3.31373 -9.205078,7.95803 -9.205078,13.1582 0,5.20017 3.57357,9.84447 9.205078,13.1582 5.631507,3.31374 13.358068,5.3418 21.884765,5.3418 8.526698,0 16.251305,-2.02806 21.882816,-5.3418 5.6315,-3.31373 9.20703,-7.95803 9.20703,-13.1582 0,-5.20017 -3.57553,-9.84447 -9.20703,-13.1582 -5.631511,-3.31374 -13.356118,-5.3418 -21.882816,-5.3418 z m 0,1 c 8.367693,0 15.937059,2.00214 21.376956,5.20312 5.43989,3.20099 8.71289,7.55593 8.71289,12.29688 0,4.74095 -3.273,9.09589 -8.71289,12.29688 -5.439897,3.20098 -13.009263,5.20312 -21.376956,5.20312 -8.367692,0 -15.937058,-2.00214 -21.376953,-5.20312 -5.439895,-3.20099 -8.71289,-7.55593 -8.71289,-12.29688 0,-4.74095 3.272995,-9.09589 8.71289,-12.29688 5.439895,-3.20098 13.009261,-5.20312 21.376953,-5.20312 z"
-             id="ellipse776-1-3-2" />
-          <text
-             text-anchor="middle"
-             x="83.239998"
-             y="-230.3"
-             font-family="Times, serif"
-             font-size="14px"
-             id="text778-0-5-7">count</text>
-        </a>
-      </g>
-    </g>
     <path
        style="fill:none;stroke:none;stroke-width:0.750136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker2183)"
        d="m 653.2822,-97.987005 0.28443,-43.961975 z"
        id="path1240"
        sodipodi:nodetypes="ccc" />
+    <g
+       id="path962">
+      <path
+         style="color:#000000;fill:#000000;-inkscape-stroke:none"
+         d="m 632.85937,-144.91211 -110.46484,64.400391 0.50391,0.863282 110.46289,-64.400393 z"
+         id="path2978" />
+      <g
+         id="g2966">
+        <g
+           id="path2968">
+          <path
+             style="color:#000000;fill:#000000;fill-rule:evenodd;stroke-width:0.800144pt;-inkscape-stroke:none"
+             d="m 518.65808,-77.754611 3.9643,-6.942172 4.02998,6.912471 z"
+             id="path2972" />
+          <path
+             style="color:#000000;fill:#000000;fill-rule:evenodd;-inkscape-stroke:none"
+             d="m 522.61719,-85.763672 -4.88086,8.546875 0.92383,-0.0039 8.91796,-0.0332 z m 0.01,2.134766 3.09766,5.314453 -6.14649,0.02344 z"
+             id="path2974" />
+        </g>
+      </g>
+    </g>
   </g>
 </svg>

--- a/docs/_static/ohsome-api-tree.txt
+++ b/docs/_static/ohsome-api-tree.txt
@@ -37,7 +37,8 @@ https://api.ohsome.org
     │       ├── bbox
     │       ├── centroid
     │       ├── geometry
-    │       └── count    
+    │       └── count
+    │           └── density
     ├── elementsFullHistory
     │   ├── bbox
     │   ├── centroid

--- a/docs/_static/ohsome-api-tree.txt
+++ b/docs/_static/ohsome-api-tree.txt
@@ -36,7 +36,8 @@ https://api.ohsome.org
     │   └── latest
     │       ├── bbox
     │       ├── centroid
-    │       └── geometry    
+    │       ├── geometry
+    │       └── count    
     ├── elementsFullHistory
     │   ├── bbox
     │   ├── centroid

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1011,9 +1011,11 @@ Contributions Aggregation
     
     * /count
     * /count/density
+    * /latest/count
 
    :query <other>: see above_
-
+   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or 'otherChanges'; 'otherChanges' filters contributions by changes that don't involve the geometry or tags; default: empty;
+   
 .. note:: The /contributions/count endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
 
 **Example request**:
@@ -1148,7 +1150,6 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
         r <- POST("https://api.ohsome.org/v1/contributions/count/density", encode = "form", body = list(bboxes = "8.69282,49.40766,8.71673,49.4133", time = "2012-01-01,2016-01-01", filter = "shop=* and type:node"))
         r
 
-
 **Example response**:
 
   .. tabs::
@@ -1218,6 +1219,111 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
 	      "fromTimestamp":"2012-01-01T00:00:00Z",
 	      "toTimestamp":"2016-01-01T00:00:00Z",
 	      "value":417.13
+	    }
+	  ]
+	}
+	
+.. http:post :: /contributions/latest/count
+
+   Get the count of the latest contributions provided to the OSM data. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters.
+
+**Example request**:
+
+Number of the latest contributions to residential buildings with a geometry change within the oldtown area of Heidelberg in 2014.
+
+  .. tabs::
+
+    .. code-tab:: bash curl (GET)
+
+       curl -X GET 'https://api.ohsome.org/v1/contributions/latest/count?bboxes=8.69282,49.40766,8.71673,49.4133&contributionType=geometryChange&filter=building=residential&time=2014-01-01/2015-01-01'
+
+    .. code-tab:: bash curl (POST)
+
+       curl -X POST 'https://api.ohsome.org/v1/contributions/latest/count' --data-urlencode 'bboxes=8.69282,49.40766,8.71673,49.4133' --data-urlenconde 'contributionType=geometryChange' --data-urlencode 'filter=building=residential' --data-urlencode 'time=2014-01-01,2015-01-01'
+
+    .. code-tab:: python Python
+
+        import requests
+        URL = 'https://api.ohsome.org/v1/contributions/latest/count'
+        data = {"bboxes": "8.69282,49.40766,8.71673,49.4133", "contributionType": "geometryChange", "filter": "building=residential", "time": "2014-01-01,2015-01-01"}
+        response = requests.post(URL, data=data)
+        print(response.json())
+
+    .. code-tab:: r R
+
+        library(httr)
+        r <- POST("https://api.ohsome.org/v1/contributions/latest/count", encode = "form", body = list(bboxes = "8.69282,49.40766,8.71673,49.4133", contributionType= "geometryChange", filter = "building=residential", time = "2014-01-01,2015-01-01"))
+        r
+
+**Example response**:
+
+  .. tabs::
+
+   .. code-tab:: json curl (GET)
+
+	{
+	  "attribution":{
+	    "url":"https://ohsome.org/copyrights",
+	    "text":"© OpenStreetMap contributors"
+	  },
+	  "apiVersion":"1.5.0",
+	  "result":[
+	    {
+	      "fromTimestamp":"2014-01-01T00:00:00Z",
+	      "toTimestamp":"2015-01-01T00:00:00Z",
+	      "value":5
+	    }
+	  ]
+	}
+
+   .. code-tab:: json curl (POST)
+
+	{
+	  "attribution":{
+	    "url":"https://ohsome.org/copyrights",
+	    "text":"© OpenStreetMap contributors"
+	  },
+	  "apiVersion":"1.5.0",
+	  "result":[
+	    {
+	      "fromTimestamp":"2014-01-01T00:00:00Z",
+	      "toTimestamp":"2015-01-01T00:00:00Z",
+	      "value":5
+	    }
+	  ]
+	}
+
+
+   .. code-tab:: json Python
+
+	{
+	  "attribution":{
+	    "url":"https://ohsome.org/copyrights",
+	    "text":"© OpenStreetMap contributors"
+	  },
+	  "apiVersion":"1.5.0",
+	  "result":[
+	    {
+	      "fromTimestamp":"2014-01-01T00:00:00Z",
+	      "toTimestamp":"2015-01-01T00:00:00Z",
+	      "value":5
+	    }
+	  ]
+	}
+
+   .. code-tab:: json R
+
+	{
+	  "attribution":{
+	    "url":"https://ohsome.org/copyrights",
+	    "text":"© OpenStreetMap contributors"
+	  },
+	  "apiVersion":"1.5.0",
+	  "result":[
+	    {
+	      "fromTimestamp":"2014-01-01T00:00:00Z",
+	      "toTimestamp":"2015-01-01T00:00:00Z",
+	      "value":5
 	    }
 	  ]
 	}

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1014,7 +1014,7 @@ Contributions Aggregation
     * /latest/count
 
    :query <other>: see above_
-   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or 'otherChanges'; 'otherChanges' filters contributions by changes that don't involve the geometry or tags; default: empty;
+   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or 'otherChanges'; 'otherChanges' filters contributions which don't match any of the other contribution types; default: empty;
    
 .. note:: The /contributions/count endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -828,12 +828,12 @@ Users Aggregation
 
 .. http:post :: /users/count
 
-    Get ``aggregation`` statistics about OSM users. Possible endpoints:
+    Get ``aggregation`` statistics about OSM users. List of endpoints:
     
-    * /count
-    * /count/groupBy/(groupType)
-    * /count/density
-    * /count/density/groupBy/(boundary or tag or type)
+    * **/count**
+    * **/count/groupBy/(groupType)**
+    * **/count/density**
+    * **/count/density/groupBy/(boundary or tag or type)**
 
     * grouping type: one of boundary_, key_, tag_, type_.
     
@@ -1007,17 +1007,19 @@ Contributions Aggregation
       
 .. http:post :: /contributions/count
 
-   Get the count of the contributions provided to the OSM data. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters. Possible endpoints:
+   Get the count of the contributions provided to the OSM data. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters. List of endpoints:
     
-    * /count
-    * /count/density
-    * /latest/count
+    * **/count**
+    * **/count/density**
+    * **/latest/count**
+    * **/latest/count/density**
 
    :query <other>: see above_
    :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or a combination of them; default: empty;
    
-.. note:: The /contributions/count endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
-.. note:: In case of multiple time intervals using the /contribution/latest endpoints, a contribution is present in a time interval only if this is the time interval in which the latest contribution of the entity happend.
+.. note:: The **/contributions/count** endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
+.. note:: If the ``contributionType`` parameter is let empty, the result could contain contributions that do not effect geometries or tags.
+.. note:: In case of multiple time intervals using the **/contribution/latest** endpoints, a contribution is present in a time interval only if this is the time interval in which the latest contribution of the entity happend.
 
 **Example request**:
 
@@ -1054,16 +1056,16 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
    .. code-tab:: json curl (GET)
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2010-01-01T00:00:00Z",
-	      "toTimestamp":"2020-01-01T00:00:00Z",
-	      "value":15.0
+	      "fromTimestamp" : "2010-01-01T00:00:00Z",
+	      "toTimestamp" : "2020-01-01T00:00:00Z",
+	      "value" : 15.0
 	    }
 	  ]
 	}
@@ -1071,16 +1073,16 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
    .. code-tab:: json curl (POST)
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2010-01-01T00:00:00Z",
-	      "toTimestamp":"2020-01-01T00:00:00Z",
-	      "value":15.0
+	      "fromTimestamp" : "2010-01-01T00:00:00Z",
+	      "toTimestamp" : "2020-01-01T00:00:00Z",
+	      "value" : 15.0
 	    }
 	  ]
 	}
@@ -1088,16 +1090,16 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
    .. code-tab:: json Python
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2010-01-01T00:00:00Z",
-	      "toTimestamp":"2020-01-01T00:00:00Z",
-	      "value":15.0
+	      "fromTimestamp" : "2010-01-01T00:00:00Z",
+	      "toTimestamp" : "2020-01-01T00:00:00Z",
+	      "value" : 15.0
 	    }
 	  ]
 	}
@@ -1105,16 +1107,16 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
    .. code-tab:: json R
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2010-01-01T00:00:00Z",
-	      "toTimestamp":"2020-01-01T00:00:00Z",
-	      "value":15.0
+	      "fromTimestamp" : "2010-01-01T00:00:00Z",
+	      "toTimestamp" : "2020-01-01T00:00:00Z",
+	      "value" : 15.0
 	    }
 	  ]
 	}
@@ -1158,16 +1160,16 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
    .. code-tab:: json curl (GET)
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2012-01-01T00:00:00Z",
-	      "toTimestamp":"2016-01-01T00:00:00Z",
-	      "value":417.13
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 417.13
 	    }
 	  ]
 	}
@@ -1175,34 +1177,33 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
    .. code-tab:: json curl (POST)
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2012-01-01T00:00:00Z",
-	      "toTimestamp":"2016-01-01T00:00:00Z",
-	      "value":417.13
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 417.13
 	    }
 	  ]
 	}
 
-
    .. code-tab:: json Python
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2012-01-01T00:00:00Z",
-	      "toTimestamp":"2016-01-01T00:00:00Z",
-	      "value":417.13
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 417.13
 	    }
 	  ]
 	}
@@ -1210,16 +1211,16 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
    .. code-tab:: json R
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.4.2",
-	  "result":[
+	  "apiVersion" : "1.4.2",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2012-01-01T00:00:00Z",
-	      "toTimestamp":"2016-01-01T00:00:00Z",
-	      "value":417.13
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 417.13
 	    }
 	  ]
 	}
@@ -1263,16 +1264,16 @@ Number of the latest contributions to residential buildings with a geometry chan
    .. code-tab:: json curl (GET)
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.5.0",
-	  "result":[
+	  "apiVersion" : "1.5.0",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2014-01-01T00:00:00Z",
-	      "toTimestamp":"2015-01-01T00:00:00Z",
-	      "value":5
+	      "fromTimestamp" : "2014-01-01T00:00:00Z",
+	      "toTimestamp" : "2015-01-01T00:00:00Z",
+	      "value" : 5
 	    }
 	  ]
 	}
@@ -1280,34 +1281,33 @@ Number of the latest contributions to residential buildings with a geometry chan
    .. code-tab:: json curl (POST)
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.5.0",
-	  "result":[
+	  "apiVersion" : "1.5.0",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2014-01-01T00:00:00Z",
-	      "toTimestamp":"2015-01-01T00:00:00Z",
-	      "value":5
+	      "fromTimestamp" : "2014-01-01T00:00:00Z",
+	      "toTimestamp" : "2015-01-01T00:00:00Z",
+	      "value" : 5
 	    }
 	  ]
 	}
 
-
    .. code-tab:: json Python
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.5.0",
-	  "result":[
+	  "apiVersion" : "1.5.0",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2014-01-01T00:00:00Z",
-	      "toTimestamp":"2015-01-01T00:00:00Z",
-	      "value":5
+	      "fromTimestamp" : "2014-01-01T00:00:00Z",
+	      "toTimestamp" : "2015-01-01T00:00:00Z",
+	      "value" : 5
 	    }
 	  ]
 	}
@@ -1315,25 +1315,130 @@ Number of the latest contributions to residential buildings with a geometry chan
    .. code-tab:: json R
 
 	{
-	  "attribution":{
-	    "url":"https://ohsome.org/copyrights",
-	    "text":"© OpenStreetMap contributors"
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion":"1.5.0",
-	  "result":[
+	  "apiVersion" : "1.5.0",
+	  "result" : [
 	    {
-	      "fromTimestamp":"2014-01-01T00:00:00Z",
-	      "toTimestamp":"2015-01-01T00:00:00Z",
-	      "value":5
+	      "fromTimestamp" : "2014-01-01T00:00:00Z",
+	      "toTimestamp" : "2015-01-01T00:00:00Z",
+	      "value" : 5
+	    }
+	  ]
+	}
+
+.. http:post :: /contributions/latest/count/density
+
+  Get the density of the count of the latest contributions in the total query area in counts per square-kilometers. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters.
+
+**Example request**:
+
+Density of the latest contributions with a geometry change to shops within the oldtown area of Heidelberg between 2012 and 2016.
+
+  .. tabs::
+
+    .. code-tab:: bash curl (GET)
+
+       curl -X GET 'https://api.ohsome.org/v1/contributions/latest/count/density?bboxes=8.69282,49.40766,8.71673,49.4133&filter=shop=* and type:node&time=2012-01-01,2016-01-01&contributionType=geometryChange'
+
+    .. code-tab:: bash curl (POST)
+
+       curl -X POST 'https://api.ohsome.org/v1/contributions/latest/count/density' --data-urlencode 'bboxes=8.69282,49.40766,8.71673,49.4133' --data-urlencode 'time=2012-01-01,2016-01-01' --data-urlencode 'filter=shop=* and type:node' --data-urlencode 'contributionType=geometryChange'
+
+    .. code-tab:: python Python
+
+        import requests
+        URL = 'https://api.ohsome.org/v1/contributions/latest/count/density'
+        data = {"bboxes": "8.69282,49.40766,8.71673,49.4133", "time": "2012-01-01,2016-01-01", "filter": "shop=* and type:node", "contributionType": "geometryChange"}
+        response = requests.post(URL, data=data)
+        print(response.json())
+
+    .. code-tab:: r R
+
+        library(httr)
+        r <- POST("https://api.ohsome.org/v1/contributions/latest/count/density", encode = "form", body = list(bboxes = "8.69282,49.40766,8.71673,49.4133", time = "2012-01-01,2016-01-01", filter = "shop=* and type:node", contributionType = "geometryChange"))
+        r
+
+**Example response**:
+
+  .. tabs::
+
+   .. code-tab:: json curl (GET)
+
+	{
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
+	  },
+	  "apiVersion" : "1.4.2",
+	  "result" : [
+	    {
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 28.48
+	    }
+	  ]
+	}
+
+   .. code-tab:: json curl (POST)
+
+	{
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
+	  },
+	  "apiVersion" : "1.4.2",
+	  "result" : [
+	    {
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 28.48
+	    }
+	  ]
+	}
+
+   .. code-tab:: json Python
+
+	{
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
+	  },
+	  "apiVersion" : "1.4.2",
+	  "result" : [
+	    {
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 28.48
+	    }
+	  ]
+	}
+
+   .. code-tab:: json R
+
+	{
+	  "attribution" : {
+	    "url" : "https://ohsome.org/copyrights",
+	    "text" : "© OpenStreetMap contributors"
+	  },
+	  "apiVersion" : "1.4.2",
+	  "result" : [
+	    {
+	      "fromTimestamp" : "2012-01-01T00:00:00Z",
+	      "toTimestamp" : "2016-01-01T00:00:00Z",
+	      "value" : 28.48
 	    }
 	  ]
 	}
 
 Elements Extraction
 -------------------
+
 .. http:post :: /elements/(geometryType)
 
-   Get the state of OSM data at the given timestamp(s) as a GeoJSON feature collection where object geometries are returned as the given ``geometryType`` (geometry, bbox, or centroid).
+   Get the state of OSM data at the given timestamp(s) as a GeoJSON feature collection where object geometries are returned as the given geometry type (``geometry``, ``bbox``, or ``centroid``).
 
    :query <other>: see above_ (except **format**)
    :query time: required; format same as described in time_
@@ -1391,10 +1496,13 @@ Get all the bike rental stations in Heidelberg.
 
       file ohsome.geojson
 
+Elements Full History Extraction
+--------------------------------
+
 .. http:post :: /elementsFullHistory/(geometryType)
 
    Get the full history of OSM data as a GeoJSON feature collection. All changes to matching OSM features are included with corresponding ``validFrom`` and ``validTo`` timestamps.
-   This endpoint supports the geometry types bbox, centroid and geometry.
+   This endpoint supports the geometry types ``bbox``, ``centroid`` and ``geometry``.
 
    :query <other>: see above_ (except **format**)
    :query time: required; must consist of two ISO-8601 conform timestrings defining a time interval; no default value
@@ -1593,7 +1701,7 @@ Contributions Extraction
 .. http:post :: /contributions/(geometryType)
 
    Get the contributions provided to the OSM data. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters.
-   This endpoint supports the geometry types bbox, centroid and geometry.
+   This endpoint supports the geometry types ``bbox``, ``centroid`` and ``geometry``.
    
    :query <other>: see above_ (except **format**)
    :query time: required; must consist of two ISO-8601 conform timestrings defining a time interval; no default value
@@ -1937,7 +2045,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
 .. http:post :: /contributions/latest/(geometryType)
 
    Get the the latest state of the contributions provided to the OSM data. This endpoint does not support the deprecated ``types``, ``keys``, ``values`` parameters.
-   This endpoint supports the geometry types bbox, centroid and geometry.
+   This endpoint supports the geometry types ``bbox``, ``centroid`` and ``geometry``.
 
    :query <other>: see above_ (except **format**)
    :query time: required; must consist of two ISO-8601 conform timestrings defining a time interval; no default value

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1014,7 +1014,7 @@ Contributions Aggregation
     * /latest/count
 
    :query <other>: see above_
-   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or 'otherChanges'; 'otherChanges' filters contributions which don't match any of the other contribution types; default: empty;
+   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange'; default: empty;
    
 .. note:: The /contributions/count endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1017,6 +1017,7 @@ Contributions Aggregation
    :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or a combination of them; default: empty;
    
 .. note:: The /contributions/count endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
+.. note:: In case of multiple time intervals using the /contribution/latest endpoints, a contribution is present in a time interval only if this is the time interval in which the latest contribution of the entity happend.
 
 **Example request**:
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1014,7 +1014,7 @@ Contributions Aggregation
     * /latest/count
 
    :query <other>: see above_
-   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange'; default: empty;
+   :query contributionType: filters contributions by contribution type: 'creation', 'deletion', 'tagChange', 'geometryChange' or a combination of them; default: empty;
    
 .. note:: The /contributions/count endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -46,7 +46,8 @@ public class ParameterDescriptions {
       + "geometries of the features should be clipped to the query's spatial boundary (‘true’), "
       + "or not (‘false’); default: ‘true’";
   public static final String CONTRIBUTION_TYPE = "Filter contributions by contribution type: "
-      + "'creation', 'deletion', 'tagChange', 'geometryChange'; no default value";
+      + "'creation', 'deletion', 'tagChange', 'geometryChange' or a combination of them;"
+      + "no default value";
 
   private ParameterDescriptions() {
     throw new IllegalStateException("Utility class");

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -45,6 +45,8 @@ public class ParameterDescriptions {
   public static final String CLIP_GEOMETRY = "Boolean operator to specify whether the returned "
       + "geometries of the features should be clipped to the query's spatial boundary (‘true’), "
       + "or not (‘false’); default: ‘true’";
+  public static final String CONTRIBUTION_TYPE = "Filter contributions by contribution type: "
+      + "'creation', 'deletion', 'tagChange', 'geometryChange' or 'otherChanges'; no default value";
 
   private ParameterDescriptions() {
     throw new IllegalStateException("Utility class");

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/ParameterDescriptions.java
@@ -46,7 +46,7 @@ public class ParameterDescriptions {
       + "geometries of the features should be clipped to the query's spatial boundary (‘true’), "
       + "or not (‘false’); default: ‘true’";
   public static final String CONTRIBUTION_TYPE = "Filter contributions by contribution type: "
-      + "'creation', 'deletion', 'tagChange', 'geometryChange' or 'otherChanges'; no default value";
+      + "'creation', 'deletion', 'tagChange', 'geometryChange'; no default value";
 
   private ParameterDescriptions() {
     throw new IllegalStateException("Utility class");

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
@@ -1,9 +1,12 @@
 package org.heigit.ohsome.ohsomeapi.controller.dataaggregation.contributions;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.heigit.ohsome.ohsomeapi.controller.ParameterDescriptions;
 import org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor;
 import org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse;
 import org.heigit.ohsome.ohsomeapi.output.Response;
@@ -34,6 +37,9 @@ public class ContributionsCountController {
       response = DefaultAggregationResponse.class)
   @RequestMapping(value = "/count", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "contributionType", value = ParameterDescriptions.CONTRIBUTION_TYPE,
+          defaultValue = "", paramType = "query", dataType = "string", required = false)})
   public Response contributionsCount(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
     ContributionsExecutor executor =
@@ -55,6 +61,9 @@ public class ContributionsCountController {
       value = "Density of OSM contributions (number of contributions divided by the "
           + "total area in square-kilometers)",
       nickname = "contributionsCountDensity", response = DefaultAggregationResponse.class)
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "contributionType", value = ParameterDescriptions.CONTRIBUTION_TYPE,
+          defaultValue = "", paramType = "query", dataType = "string", required = false)})
   @RequestMapping(value = "/count/density", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response contributionsCountDensity(HttpServletRequest servletRequest,
@@ -76,6 +85,9 @@ public class ContributionsCountController {
    */
   @ApiOperation(value = "Count of latest OSM contributions", nickname = "contributionsLatestCount",
       response = DefaultAggregationResponse.class)
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "contributionType", value = ParameterDescriptions.CONTRIBUTION_TYPE,
+          defaultValue = "", paramType = "query", dataType = "string", required = false)})
   @RequestMapping(value = "/latest/count", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response contributionsLatestCount(HttpServletRequest servletRequest,

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
@@ -72,7 +72,7 @@ public class ContributionsCountController {
   }
 
   /**
-   * Gives the count of latest OSM contributions.
+   * Gives the density of latest OSM contributions.
    *
    * @param servletRequest <code>HttpServletRequest</code> of the incoming request
    * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
@@ -80,6 +80,31 @@ public class ContributionsCountController {
    *         DefaultAggregationResponse}
    * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
    *         #count(boolean, boolean) count}
+   */
+  @ApiOperation(
+      value = "Density of the latest OSM contributions (number of contributions divided by the "
+          + "total area in square-kilometers)",
+      nickname = "contributionsLatestCountDensity", response = DefaultAggregationResponse.class)
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "contributionType", value = ParameterDescriptions.CONTRIBUTION_TYPE,
+          defaultValue = "", paramType = "query", dataType = "string", required = false)})
+  @RequestMapping(value = "/latest/count/density", method = {RequestMethod.GET, RequestMethod.POST},
+      produces = {"application/json", "text/csv"})
+  public Response contributionsLatestCountDensity(HttpServletRequest servletRequest,
+      HttpServletResponse servletResponse) throws Exception {
+    var executor = new ContributionsExecutor(servletRequest, servletResponse, true);
+    return executor.count(false, true);
+  }
+
+  /**
+   * Gives the count of latest OSM contributions.
+   *
+   * @param servletRequest <code>HttpServletRequest</code> of the incoming request
+   * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
+   * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
+   *         DefaultAggregationResponse}
+   * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #count (boolean,boolean) count}
    */
   @ApiOperation(value = "Count of latest OSM contributions", nickname = "contributionsLatestCount",
       response = DefaultAggregationResponse.class)

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
@@ -31,7 +31,7 @@ public class ContributionsCountController {
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
    * @throws Exception thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count(boolean) count}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count count}
    */
   @ApiOperation(value = "Count of OSM contributions", nickname = "contributionsCount",
       response = DefaultAggregationResponse.class)
@@ -54,7 +54,7 @@ public class ContributionsCountController {
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
    * @throws Exception thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count(boolean) count}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count count}
    */
   @ApiOperation(
       value = "Density of OSM contributions (number of contributions divided by the "
@@ -79,7 +79,7 @@ public class ContributionsCountController {
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
    * @throws Exception thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count(boolean) count}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count count}
    */
   @ApiOperation(value = "Count of latest OSM contributions", nickname = "contributionsLatestCount",
       response = DefaultAggregationResponse.class)

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
@@ -30,8 +30,8 @@ public class ContributionsCountController {
    * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
-   * @throws Exception thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count count}
+   * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #count(boolean, boolean) count}
    */
   @ApiOperation(value = "Count of OSM contributions", nickname = "contributionsCount",
       response = DefaultAggregationResponse.class)
@@ -53,8 +53,8 @@ public class ContributionsCountController {
    * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
-   * @throws Exception thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count count}
+   * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #count(boolean, boolean) count}
    */
   @ApiOperation(
       value = "Density of OSM contributions (number of contributions divided by the "
@@ -78,8 +78,8 @@ public class ContributionsCountController {
    * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
-   * @throws Exception thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count count}
+   * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #count(boolean, boolean) count}
    */
   @ApiOperation(value = "Count of latest OSM contributions", nickname = "contributionsLatestCount",
       response = DefaultAggregationResponse.class)

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
@@ -42,8 +42,7 @@ public class ContributionsCountController {
           defaultValue = "", paramType = "query", dataType = "string", required = false)})
   public Response contributionsCount(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
-    ContributionsExecutor executor =
-        new ContributionsExecutor(servletRequest, servletResponse, false);
+    var executor = new ContributionsExecutor(servletRequest, servletResponse, false);
     return executor.count(false, false);
   }
 
@@ -68,8 +67,7 @@ public class ContributionsCountController {
       produces = {"application/json", "text/csv"})
   public Response contributionsCountDensity(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
-    ContributionsExecutor executor =
-        new ContributionsExecutor(servletRequest, servletResponse, true);
+    var executor = new ContributionsExecutor(servletRequest, servletResponse, true);
     return executor.count(false, false);
   }
 
@@ -92,8 +90,7 @@ public class ContributionsCountController {
       produces = {"application/json", "text/csv"})
   public Response contributionsLatestCount(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
-    ContributionsExecutor executor =
-        new ContributionsExecutor(servletRequest, servletResponse, false);
+    var executor = new ContributionsExecutor(servletRequest, servletResponse, false);
     return executor.count(false, true);
   }
 }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/contributions/ContributionsCountController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Api(tags = "Contributions Count")
 @RestController
-@RequestMapping("/contributions/count")
+@RequestMapping("/contributions")
 public class ContributionsCountController {
 
   /**
@@ -32,13 +32,13 @@ public class ContributionsCountController {
    */
   @ApiOperation(value = "Count of OSM contributions", nickname = "contributionsCount",
       response = DefaultAggregationResponse.class)
-  @RequestMapping(value = "", method = {RequestMethod.GET, RequestMethod.POST},
+  @RequestMapping(value = "/count", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response contributionsCount(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
     ContributionsExecutor executor =
         new ContributionsExecutor(servletRequest, servletResponse, false);
-    return executor.count(false);
+    return executor.count(false, false);
   }
 
   /**
@@ -55,13 +55,33 @@ public class ContributionsCountController {
       value = "Density of OSM contributions (number of contributions divided by the "
           + "total area in square-kilometers)",
       nickname = "contributionsCountDensity", response = DefaultAggregationResponse.class)
-  @RequestMapping(value = "/density", method = {RequestMethod.GET, RequestMethod.POST},
+  @RequestMapping(value = "/count/density", method = {RequestMethod.GET, RequestMethod.POST},
       produces = {"application/json", "text/csv"})
   public Response contributionsCountDensity(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) throws Exception {
     ContributionsExecutor executor =
         new ContributionsExecutor(servletRequest, servletResponse, true);
-    return executor.count(false);
+    return executor.count(false, false);
   }
 
+  /**
+   * Gives the count of latest OSM contributions.
+   *
+   * @param servletRequest <code>HttpServletRequest</code> of the incoming request
+   * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
+   * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
+   *         DefaultAggregationResponse}
+   * @throws Exception thrown by
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count(boolean) count}
+   */
+  @ApiOperation(value = "Count of latest OSM contributions", nickname = "contributionsLatestCount",
+      response = DefaultAggregationResponse.class)
+  @RequestMapping(value = "/latest/count", method = {RequestMethod.GET, RequestMethod.POST},
+      produces = {"application/json", "text/csv"})
+  public Response contributionsLatestCount(HttpServletRequest servletRequest,
+      HttpServletResponse servletResponse) throws Exception {
+    ContributionsExecutor executor =
+        new ContributionsExecutor(servletRequest, servletResponse, false);
+    return executor.count(false, true);
+  }
 }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/users/UsersController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/users/UsersController.java
@@ -30,8 +30,8 @@ public class UsersController {
    * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
-   * @throws Exception thrown by {@link
-   *         org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count(boolean) count}
+   * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #count(boolean, boolean) count}
    */
   @ApiOperation(value = "Count of OSM users", nickname = "count",
       response = DefaultAggregationResponse.class)
@@ -134,8 +134,8 @@ public class UsersController {
    * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
    * @return {@link org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse
    *         DefaultAggregationResponse}
-   * @throws Exception thrown by {@link
-   *         org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#count(boolean) count}
+   * @throws Exception thrown by {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #count(boolean, boolean) count}
    */
   @ApiOperation(
       value = "Density of OSM users (number of users divided "

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/users/UsersController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/dataaggregation/users/UsersController.java
@@ -41,7 +41,7 @@ public class UsersController {
       throws Exception {
     ContributionsExecutor executor =
         new ContributionsExecutor(servletRequest, servletResponse, false);
-    return executor.count(true);
+    return executor.count(true, false);
   }
 
   /**
@@ -147,7 +147,7 @@ public class UsersController {
       HttpServletResponse servletResponse) throws Exception {
     ContributionsExecutor executor =
         new ContributionsExecutor(servletRequest, servletResponse, true);
-    return executor.count(true);
+    return executor.count(true, false);
   }
 
   /**

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/AggregateRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/AggregateRequestExecutor.java
@@ -248,7 +248,7 @@ public class AggregateRequestExecutor extends RequestExecutor {
       throws IOException {
     setCsvSettingsInServletResponse();
     try (CSVWriter writer =
-        new CSVWriter(servletResponse.getWriter(), ';', CSVWriter.DEFAULT_QUOTE_CHARACTER,
+          new CSVWriter(servletResponse.getWriter(), ';', CSVWriter.DEFAULT_QUOTE_CHARACTER,
             CSVWriter.DEFAULT_ESCAPE_CHARACTER, CSVWriter.DEFAULT_LINE_END);) {
       writer.writeAll(comments, false);
       consumer.accept(writer);

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -90,7 +90,7 @@ public class ContributionsExecutor extends RequestExecutor {
           inputProcessor.getRequestUrlIfGetRequest(servletRequest));
     }
     if ("csv".equalsIgnoreCase(requestParameters.getFormat())) {
-      ExecutionUtils exeUtils = new ExecutionUtils(processingData);
+      var exeUtils = new ExecutionUtils(processingData);
       exeUtils.writeCsvResponse(results, servletResponse,
           ExecutionUtils.createCsvTopComments(URL, TEXT, Application.API_VERSION, metadata));
       return null;

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -1,4 +1,3 @@
-
 package org.heigit.ohsome.ohsomeapi.executor;
 
 import java.util.ArrayList;
@@ -75,7 +74,8 @@ public class ContributionsExecutor extends RequestExecutor {
     MapReducer<OSMContribution> mapRed;
     final SortedMap<OSHDBTimestamp, ? extends Number> result;
     if (isContributionsLatestCount) {
-      // otherwise the MapReducer will be filtered in the Inputprocessor
+      // the setFullHistory flag needs to be set, because
+      // otherwise the MapReducer would be filtered in the Inputprocessor
       // preventing the call of groupByEntity() in contributionsCount()
       inputProcessor.getProcessingData().setFullHistory(true);
     }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -36,6 +36,13 @@ public class ContributionsExecutor extends RequestExecutor {
   private final ProcessingData processingData;
   private final long startTime = System.currentTimeMillis();
 
+  /**
+   * Initializes a newly created <code>ContributionsExecutor</code> object.
+   *
+   * @param isDensity the boolean value relative to the density resource
+   * @param servletRequest <code>HttpServletRequest</code> of the incoming request
+   * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
+   */
   public ContributionsExecutor(HttpServletRequest servletRequest,
       HttpServletResponse servletResponse, boolean isDensity) {
     super(servletRequest, servletResponse);
@@ -103,14 +110,15 @@ public class ContributionsExecutor extends RequestExecutor {
     return DefaultAggregationResponse.of(new Attribution(URL, TEXT), Application.API_VERSION,
         metadata, results);
   }
-  
+
   /**
    * Performs a count calculation for /users/count.
-   * 
+   *
    * @param mapRed a MapReducer of OSM contributions
    * @return SortedMap with counts of users aggregated by timestamp
-   * @throws Exception thrown by {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator
-   * #countUniq() countUniq}
+   * @throws Exception thrown by
+   *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator #countUniq()
+   *         countUniq}
    * @throws UnsupportedOperationException thrown by
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer#aggregateByTimestamp()
    *         aggregateByTimeStamp}
@@ -119,16 +127,16 @@ public class ContributionsExecutor extends RequestExecutor {
       throws UnsupportedOperationException, Exception {
     return mapRed.aggregateByTimestamp().map(OSMContribution::getContributorUserId).countUniq();
   }
-  
+
   /**
    * Performs a count calculation for /contributions/count, /contributions/density or
    * /contribution/latest/count.
-   * 
+   *
    * @param mapRed a MapReducer of OSM contributions
-   * @param isContributionsLatest the boolean value relative to the endpoint /contributions/latest 
+   * @param isContributionsLatest the boolean value relative to the endpoint /contributions/latest
    * @return SortedMap with counts of contributions aggregated by timestamp
-   * @throws Exception thrown by {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator
-   *         #count() count}
+   * @throws Exception thrown by
+   *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator #count() count}
    * @throws UnsupportedOperationException thrown by
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer#aggregateByTimestamp()
    *         aggregateByTimeStamp}
@@ -151,7 +159,7 @@ public class ContributionsExecutor extends RequestExecutor {
 
   /**
    * Filters contributions by contribution type.
-   * 
+   *
    * @param mapRed a MapReducer to be filtered
    * @return MapReducer filtered by contribution type
    */

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -54,11 +54,14 @@ public class ContributionsExecutor extends RequestExecutor {
    * @throws Exception thrown by
    *         {@link org.heigit.ohsome.ohsomeapi.inputprocessing.InputProcessor#processParameters()
    *         processParameters},
+   *         {@link org.heigit.ohsome.ohsomeapi.inputprocessing.InputProcessor
+   *         #processParameters(ComputeMode) processParameters} and
    *         {@link org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator#count() count}
    * @throws UnsupportedOperationException thrown by
-   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor#usersCount
-   *         usersCount} and {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
-   *         #contributionsCount contributionsCount}
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #usersCount(MapReducer) usersCount} and
+   *         {@link org.heigit.ohsome.ohsomeapi.executor.ContributionsExecutor
+   *         #contributionsCount(MapReducer, boolean) contributionsCount}
    */
   public Response count(boolean isUsersRequest, boolean isContributionsLatestCount)
       throws UnsupportedOperationException, Exception {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -159,21 +159,17 @@ public class ContributionsExecutor extends RequestExecutor {
       return mapRed;
     }
     List<String> contrTypes =
-        Arrays.asList("CREATION", "DELETION", "GEOMETRYCHANGE", "TAGCHANGE", "OTHERCHANGES");
+        Arrays.asList("CREATION", "DELETION", "GEOMETRYCHANGE", "TAGCHANGE");
     contributionType = contributionType.toUpperCase();
     if (!contrTypes.contains(contributionType)) {
       throw new BadRequestException(
-          "The contribution type must be 'creation', 'deletion', 'geometryChange', 'tagChange' "
-              + "or 'otherChanges'.");
+          "The contribution type must be 'creation', 'deletion', 'geometryChange', 'tagChange' or"
+          + "a combination of them");
     }
-    if (contributionType.equals("OTHERCHANGES")) {
-      return mapRed.filter(contr -> contr.getContributionTypes().isEmpty());
-    } else {
-      var string = new StringBuilder(contributionType);
-      if (contributionType.equals("TAGCHANGE") || contributionType.equals("GEOMETRYCHANGE")) {
-        string.insert(contributionType.length() - 6, '_');
-      }
-      return mapRed.filter(contr -> contr.is(ContributionType.valueOf(string.toString())));
+    var string = new StringBuilder(contributionType);
+    if (contributionType.equals("TAGCHANGE") || contributionType.equals("GEOMETRYCHANGE")) {
+      string.insert(contributionType.length() - 6, '_');
     }
+    return mapRed.filter(contr -> contr.is(ContributionType.valueOf(string.toString())));
   }
 }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -26,7 +26,8 @@ import org.locationtech.jts.geom.Geometry;
 
 /**
  * Includes the execute method for requests mapped to /contributions/count,
- * /contributions/count/density, /contributions/latest/count and /users/count.
+ * /contributions/count/density, /contributions/latest/count, /contributions/latest/count/density
+ * and /users/count.
  */
 public class ContributionsExecutor extends RequestExecutor {
 
@@ -50,7 +51,8 @@ public class ContributionsExecutor extends RequestExecutor {
 
   /**
    * Handler method for count calculation of the endpoints /contributions/count,
-   * /contributions/density, /contribution/latest/count or /users/count.
+   * /contributions/density, /contribution/latest/count, /contributions/latest/count/density
+   * or /users/count.
    *
    * @param isUsersRequest the boolean value relative to the endpoint /users/count
    * @param isContributionsLatestCount the boolean value relative to the endpoint
@@ -128,8 +130,8 @@ public class ContributionsExecutor extends RequestExecutor {
   }
 
   /**
-   * Performs a count calculation for /contributions/count, /contributions/density or
-   * /contribution/latest/count.
+   * Performs a count calculation for /contributions/count, /contributions/density,
+   * /contribution/latest/count or /contributions/latest/count/density.
    *
    * @param mapRed a MapReducer of OSM contributions
    * @param isContributionsLatest the boolean value relative to the endpoint /contributions/latest

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.ohsomeapi.executor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -169,32 +168,26 @@ public class ContributionsExecutor extends RequestExecutor {
       return mapRed;
     }
     types = types.toUpperCase();
-    List<String> givenTypes = Arrays.asList(types.split(","));
-    for (int i = 0; i < givenTypes.size(); i++) {
-      switch (givenTypes.get(i)) {
-        case "TAGCHANGE":
-          givenTypes.set(i, "TAG_CHANGE");
-          break;
-        case "GEOMETRYCHANGE":
-          givenTypes.set(i, "GEOMETRY_CHANGE");
-          break;
+    List<ContributionType> contributionTypes = new ArrayList<>();
+    for (String givenType : types.split(",")) {
+      switch (givenType) {
         case "CREATION":
+          contributionTypes.add(ContributionType.CREATION);
           break;
         case "DELETION":
+          contributionTypes.add(ContributionType.DELETION);
+          break;
+        case "TAGCHANGE":
+          contributionTypes.add(ContributionType.TAG_CHANGE);
+          break;
+        case "GEOMETRYCHANGE":
+          contributionTypes.add(ContributionType.GEOMETRY_CHANGE);
           break;
         default:
           throw new BadRequestException("The contribution type must be 'creation', 'deletion',"
               + "'geometryChange', 'tagChange' or a combination of them");
       }
     }
-    List<ContributionType> contributionTypes = new ArrayList<>();
-    givenTypes.stream().forEach(givenType -> {
-      for (ContributionType contrType : ContributionType.values()) {
-        if (contrType.name().equals(givenType)) {
-          contributionTypes.add(contrType);
-        }
-      }
-    });
     return mapRed.filter(contr -> contributionTypes.stream().anyMatch(contr::is));
   }
 }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.SortedMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite.ComputeMode;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
@@ -17,7 +16,6 @@ import org.heigit.ohsome.ohsomeapi.Application;
 import org.heigit.ohsome.ohsomeapi.exception.BadRequestException;
 import org.heigit.ohsome.ohsomeapi.inputprocessing.InputProcessor;
 import org.heigit.ohsome.ohsomeapi.inputprocessing.ProcessingData;
-import org.heigit.ohsome.ohsomeapi.oshdb.DbConnData;
 import org.heigit.ohsome.ohsomeapi.output.Attribution;
 import org.heigit.ohsome.ohsomeapi.output.DefaultAggregationResponse;
 import org.heigit.ohsome.ohsomeapi.output.Description;
@@ -72,14 +70,7 @@ public class ContributionsExecutor extends RequestExecutor {
       // preventing the call of groupByEntity() in contributionsCount()
       inputProcessor.getProcessingData().setFullHistory(true);
     }
-    if (DbConnData.db instanceof OSHDBIgnite) {
-      // on ignite: Use AffinityCall backend, which is the only one properly supporting streaming
-      // of result data, without buffering the whole result in memory before returning the result.
-      // This allows to write data out to the client via a chunked HTTP response.
-      mapRed = inputProcessor.processParameters(ComputeMode.AffinityCall);
-    } else {
-      mapRed = inputProcessor.processParameters();
-    }
+    mapRed = inputProcessor.processParameters();
     if (isUsersRequest) {
       result = usersCount(mapRed);
     } else {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -54,7 +54,9 @@ public class ContributionsExecutor extends RequestExecutor {
       throws Exception {
     MapReducer<OSMContribution> mapRed;
     final SortedMap<OSHDBTimestamp, ? extends Number> result;
-    inputProcessor.getProcessingData().setFullHistory(true);
+    if (isContributionsLatestCount) {
+      inputProcessor.getProcessingData().setFullHistory(true);
+    }
     if (DbConnData.db instanceof OSHDBIgnite) {
       // on ignite: Use AffinityCall backend, which is the only one properly supporting streaming
       // of result data, without buffering the whole result in memory before returning the result.

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -68,6 +68,8 @@ public class ContributionsExecutor extends RequestExecutor {
     MapReducer<OSMContribution> mapRed;
     final SortedMap<OSHDBTimestamp, ? extends Number> result;
     if (isContributionsLatestCount) {
+      // otherwise the MapReducer will be filtered in the Inputprocessor
+      // preventing the call of groupByEntity() in contributionsCount()
       inputProcessor.getProcessingData().setFullHistory(true);
     }
     if (DbConnData.db instanceof OSHDBIgnite) {

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.SortedMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite.ComputeMode;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -226,7 +226,6 @@ public class DataExtractionTransformer implements Serializable {
    */
   public List<Feature> buildUnchangedFeatures(OSMEntitySnapshot snapshot) {
     Map<String, Object> properties = new TreeMap<>();
-    OSMEntity entity = snapshot.getEntity();
     Geometry geom;
     if (clipGeometries) {
       geom = snapshot.getGeometry();
@@ -235,6 +234,7 @@ public class DataExtractionTransformer implements Serializable {
     }
     properties.put(VALID_FROM_PROPERTY, startTimestamp);
     properties.put(VALID_TO_PROPERTY, endTimestamp);
+    OSMEntity entity = snapshot.getEntity();
     boolean addToOutput = addEntityToOutput(entity, geom);
     if (addToOutput) {
       return Collections.singletonList(exeUtils.createOSMFeature(entity, geom, properties,

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/ResourceParameters.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/ResourceParameters.java
@@ -44,8 +44,11 @@ public class ResourceParameters {
       possibleParams.add("properties");
       possibleParams.add("clipGeometry");
     }
-    // removing deprecated params from newer endpoint
     if (uri.contains("/contributions")) {
+      if (uri.contains("/count")) {
+        possibleParams.add("contributionType");
+      }
+      // removing deprecated params from newer endpoint
       possibleParams.remove("types");
       possibleParams.remove("keys");
       possibleParams.remove("values");

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -682,6 +682,62 @@ public class GetControllerTest {
   }
 
   /*
+   * /contributions tests
+   */
+
+  @Test
+  public void contributionsLatestCountTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> responseAggregation =
+        restTemplate.getForEntity(server + port
+            + "/contributions/latest/count?bboxes=8.67,49.39,8.71,49.42"
+            + "&filter=type:way and natural=*&format=json&time=2014-01-01/2017-01-01/P1Y",
+        JsonNode.class);
+    ResponseEntity<JsonNode> responseExtraction = restTemplate.getForEntity(server + port
+        + "/contributions/latest/bbox?bboxes=8.67,49.39,8.71,49.42&filter=type:way and natural=*"
+        + "&properties=tags&time=2014-01-01,2017-01-01",
+        JsonNode.class);
+    int sumAggregation = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(responseAggregation.getBody().get("result").iterator(),
+            Spliterator.ORDERED),
+        false).mapToInt(node -> node.get("value").asInt()).sum();
+    long sumExtraction =
+        StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(
+                responseExtraction.getBody().get("features").iterator(), Spliterator.ORDERED),
+            false).count();
+    assertEquals(sumExtraction, sumAggregation);
+  }
+
+  @Test
+  public void contributionsLatestCountFilteredByGeometryChange() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
+        + "building=residential&format=json&time=2016-01-01/2020-01-01/P1Y&"
+        + "contributionType=geometryChange", JsonNode.class);
+    int sum = StreamSupport
+        .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
+            Spliterator.ORDERED), false)
+        .mapToInt(node -> node.get("value").asInt()).sum();
+    assertEquals(4, sum);
+  }
+
+  @Test
+  public void contributionsLatestCountFilteredByTagChange() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
+        + "building=residential&format=json&time=2016-01-01/2020-01-01/P1Y&"
+        + "contributionType=tagChange", JsonNode.class);
+    int sum = StreamSupport
+        .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
+            Spliterator.ORDERED), false)
+        .mapToInt(node -> node.get("value").asInt()).sum();
+    assertEquals(1, sum);
+  }
+  
+  /*
    * csv output tests start here
    */
   @Test

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -751,6 +751,18 @@ public class GetControllerTest {
     assertEquals(5, sum);
   }
 
+  @Test
+  public void contributionsLatestCountDensityFilteredByTagChange() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(
+        server + port + "/contributions/latest/count/density?"
+            + "bboxes=8.680215,49.416382,8.683867,49.417321&contributionType=tagchange&"
+            + "filter=type:way and building=residential&format=json&time=2014-01-01/2019-01-01",
+        JsonNode.class);
+    assertEquals(36.14, response.getBody().get("result").get(0).get("value").asDouble(),
+        deltaPercentage);
+  }
+
   /*
    * csv output tests start here
    */

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -720,7 +720,7 @@ public class GetControllerTest {
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)
         .mapToInt(node -> node.get("value").asInt()).sum();
-    assertEquals(4, sum);
+    assertEquals(7, sum);
   }
 
   @Test
@@ -734,7 +734,7 @@ public class GetControllerTest {
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)
         .mapToInt(node -> node.get("value").asInt()).sum();
-    assertEquals(1, sum);
+    assertEquals(4, sum);
   }
   
   /*

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -713,22 +713,22 @@ public class GetControllerTest {
   public void contributionsLatestCountFilteredByGeometryChange() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
-        + "building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
+        + "/contributions/latest/count?bboxes=8.673088,49.401834,8.692051,49.407979&"
+        + "filter=type:way and building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
         + "contributionType=geometryChange", JsonNode.class);
     int sum = StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)
         .mapToInt(node -> node.get("value").asInt()).sum();
-    assertEquals(4, sum);
+    assertEquals(2, sum);
   }
 
   @Test
   public void contributionsLatestCountFilteredByTagChange() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
-        + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
-        + "building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
+        + "/contributions/latest/count?bboxes=8.673088,49.401834,8.692051,49.407979&"
+        + "filter=type:way and building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
         + "contributionType=tagChange", JsonNode.class);
     int sum = StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
@@ -737,6 +737,20 @@ public class GetControllerTest {
     assertEquals(4, sum);
   }
   
+  @Test
+  public void contributionsLatestCountFilteredByTagChangeAndGeometryChange() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/contributions/latest/count?bboxes=8.673088,49.401834,8.692051,49.407979"
+        + "&filter=type:way and building=residential&format=json&time=2017-01-01/2019-01-01&"
+        + "contributionType=tagChange,geometryChange", JsonNode.class);
+    int sum = StreamSupport
+        .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
+            Spliterator.ORDERED), false)
+        .mapToInt(node -> node.get("value").asInt()).sum();
+    assertEquals(5, sum);
+  }
+
   /*
    * csv output tests start here
    */

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -715,7 +715,7 @@ public class GetControllerTest {
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
         + "building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
-        + "contributionType=geometryChange", JsonNode.class);    
+        + "contributionType=geometryChange", JsonNode.class);
     int sum = StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -714,13 +714,13 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
-        + "building=residential&format=json&time=2016-01-01/2020-01-01/P1Y&"
-        + "contributionType=geometryChange", JsonNode.class);
+        + "building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
+        + "contributionType=geometryChange", JsonNode.class);    
     int sum = StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),
             Spliterator.ORDERED), false)
         .mapToInt(node -> node.get("value").asInt()).sum();
-    assertEquals(7, sum);
+    assertEquals(4, sum);
   }
 
   @Test
@@ -728,7 +728,7 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/contributions/count?bboxes=8.673088,49.401834,8.692051,49.407979&filter=type:way and "
-        + "building=residential&format=json&time=2016-01-01/2020-01-01/P1Y&"
+        + "building=residential&format=json&time=2016-01-01/2019-01-01/P1Y&"
         + "contributionType=tagChange", JsonNode.class);
     int sum = StreamSupport
         .stream(Spliterators.spliteratorUnknownSize(response.getBody().get("result").iterator(),

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -736,7 +736,7 @@ public class GetControllerTest {
         .mapToInt(node -> node.get("value").asInt()).sum();
     assertEquals(4, sum);
   }
-  
+
   @Test
   public void contributionsLatestCountFilteredByTagChangeAndGeometryChange() {
     TestRestTemplate restTemplate = new TestRestTemplate();


### PR DESCRIPTION
### Description
It adds the endpoint `/contributions/latest/count`, `/contributions/latest/count/density` and the new parameter `contributionType` for all the contributions aggregation endpoints. Through the new parameter, it is possible to filter contributions by `creation`, `deletion`, `geometryChange`, `tagChange` or a combination of them.

### Corresponding issue
Closes #174 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit and API tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
