### PR TITLE
return "@contributionChangesetId" for contribution extraction endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### New Features
 
 * add new `contributionTypes` property to `properties` parameter ([#136])
+* contribution extraction endpoints now return the `@contributionChangesetId` as a separate field
 
 ### Bug Fixes
 

--- a/docs/response-parameters.rst
+++ b/docs/response-parameters.rst
@@ -57,12 +57,15 @@ Description of the custom response parameters that are marked with a leading ``@
 **specific for /contributions**
 
 * ``@timestamp`` - indicates when this contribution occurred
+* ``@contributionChangsetId`` - id of the OSM changeset where the contribution was performed
 * ``@creation`` - contribution type; indicates if the OSM element newly fits the query's requirements: either because it is freshly created, moved into the query's area of interest, or is now matching the defined filter parameter (true); cannot occur in combination with other contribution types
 * ``@geometryChange`` - contribution type; indicates if the geometry of the OSM element has changed (true); can occur in combination with @tagChange
 * ``@tagChange``- contribution type; indicates if the tags of this OSM element have changed (true); can occur in combination with @geometryChange
 * ``@deletion`` - contribution type; indicates if the OSM element does not match the query requirements anymore: either because it got deleted, moved outside of the query area of interest, or is not matching the defined filter anymore (true); cannot occur in combination with other contribution types
 
 .. note:: No `contribution type` can occur with having ``false`` as a value. If any of them is present, the value is always ``true``.
+
+.. note:: The `@contributionChangsetId` can be different from the general `@changesetId` in cases where a contribution stems from changes child elements referenced by an OSM element, e.g. when only the nodes of an OSM way are rearranged or moved. This is sometimes called a "minor version".
 
 Metadata
 --------

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -27,6 +27,7 @@ public class DataExtractionTransformer implements Serializable {
   private static final String VALID_TO_PROPERTY = "@validTo";
   private static final String VALID_FROM_PROPERTY = "@validFrom";
   private static final String TIMESTAMP_PROPERTY = "@timestamp";
+  private static final String CONTRIBUTION_CHANGESET_ID_PROPERTY = "@contributionChangesetId";
 
   private final String startTimestamp;
   private final String endTimestamp;
@@ -153,6 +154,7 @@ public class DataExtractionTransformer implements Serializable {
               properties.put(VALID_TO_PROPERTY, validTo);
             } else {
               properties.put(TIMESTAMP_PROPERTY, validTo);
+              properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, contribution.getChangesetId());
             }
             output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
                 includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
@@ -185,6 +187,7 @@ public class DataExtractionTransformer implements Serializable {
       } else {
         properties.put(TIMESTAMP_PROPERTY,
             TimestampFormatter.getInstance().isoDateTime(lastContribution.getTimestamp()));
+        properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, lastContribution.getChangesetId());
       }
       if (!currentGeom.isEmpty()) {
         boolean addToOutput = addEntityToOutput(currentEntity, currentGeom);
@@ -200,6 +203,7 @@ public class DataExtractionTransformer implements Serializable {
       properties = new TreeMap<>();
       properties.put(TIMESTAMP_PROPERTY,
           TimestampFormatter.getInstance().isoDateTime(lastContribution.getTimestamp()));
+      properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, lastContribution.getChangesetId());
       output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt, false,
           includeOSMMetadata, includeContributionTypes, isContributionsEndpoint, outputGeometry,
           lastContribution.getContributionTypes()));


### PR DESCRIPTION
### Description

Returns the "minor version's" changeset id as `@contributionChangesetId` for contribution extraction endpoints.

To be discussed: strictly speaking, this is not quite what the current (version `1.4.1`) [docs](https://docs.ohsome.org/ohsome-api/v1/response-parameters.html#contribution-parameters) say about the `@changesetId` parameter:

> `@changesetId` - id of the OSM changeset where the contribution was performed

We could technically backport this as a patch release into the 1.4 branch. Not sure if it's worth it… :thinking: 

### Corresponding issue
Closes #199 

### Checklist
- [ ] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [ ] I have added sufficient unit and API tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
