### PR TITLE
Throw an exception for `bpolys` and `bcircles` boundaries lying outside the underlying data-extract polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@ Changelog
 
 ## 1.6.0-SNAPSHOT (current master)
 
+### New Features
+
+
+
+### Bug Fixes
+
+* fix not thrown exception in case of `bpolys` and `bcircles` boundaries not lying completely within the underlying data-extract polygon ([#201])
+
+### Performance and Code Quality
+
+
+
+### Other Changes
+
+* adapt error message for contributions extration endpoint in case of wrong `time` parameter value ([#208])
+
+[#201]: https://github.com/GIScience/ohsome-api/issues/201
+[#208]: https://github.com/GIScience/ohsome-api/issues/208
+
 
 ## 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,9 @@ Changelog
 
 ## 1.6.0-SNAPSHOT (current master)
 
-### New Features
-
-
-
 ### Bug Fixes
 
 * fix not thrown exception in case of `bpolys` and `bcircles` boundaries not lying completely within the underlying data-extract polygon ([#201])
-
-### Performance and Code Quality
-
-
 
 ### Other Changes
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -47,8 +47,8 @@ public class ExceptionMessages {
   public static final String SHOWMETADATA_PARAM = "The showMetadata parameter can only contain the "
       + "values 'true', 'yes', 'false', or 'no'.";
   public static final String TIME_FORMAT = "The provided time parameter is not ISO-8601 conform.";
-  public static final String TIME_FORMAT_FULL_HISTORY = "Wrong time parameter. You need to give "
-      + "exactly two ISO-8601 conform timestamps, if you want to use the full-history extraction.";
+  public static final String TIME_FORMAT_CONTRS_EXTRACTION_AND_FULL_HISTORY =
+      "Wrong time parameter. You need to give exactly two ISO-8601 conform timestamps.";
   public static final String TIME_FORMAT_CONTRIBUTION =
       "You need to give at least two timestamps or a time interval for this resource.";
   public static final String TIMEOUT = "The given timeout is too long. It has to be shorter than ";

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataRequestExecutor.java
@@ -79,7 +79,8 @@ public class DataRequestExecutor extends RequestExecutor {
     String[] time = inputProcessor.splitParamOnComma(
         inputProcessor.createEmptyArrayIfNull(servletRequest.getParameterValues("time")));
     if (time.length != 2) {
-      throw new BadRequestException(ExceptionMessages.TIME_FORMAT_FULL_HISTORY);
+      throw new BadRequestException(
+          ExceptionMessages.TIME_FORMAT_CONTRS_EXTRACTION_AND_FULL_HISTORY);
     }
     TagTranslator tt = DbConnData.tagTranslator;
     String[] keys = requestParameters.getKeys();

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/GeometryBuilder.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/GeometryBuilder.java
@@ -121,6 +121,9 @@ public class GeometryBuilder {
         transform = CRS.findMathTransform(targetCrs, sourceCrs, false);
         geom = JTS.transform(buffer, transform);
         if (bpoints.length == 3) {
+          if (!utils.isWithin(geom)) {
+            throw new NotFoundException(ExceptionMessages.BOUNDARY_NOT_IN_DATA_EXTRACT);
+          }
           geometryList.add(geom);
           processingData.setBoundaryList(geometryList);
           processingData.setRequestGeom(geom);
@@ -154,6 +157,7 @@ public class GeometryBuilder {
     Geometry bpoly;
     ArrayList<Coordinate> coords = new ArrayList<>();
     ArrayList<Geometry> geometryList = new ArrayList<>();
+    InputProcessingUtils utils = new InputProcessingUtils();
     if (bpolys[0].equals(bpolys[bpolys.length - 2])
         && bpolys[1].equals(bpolys[bpolys.length - 1])) {
       try {
@@ -165,6 +169,9 @@ public class GeometryBuilder {
         throw new BadRequestException(ExceptionMessages.BPOLYS_FORMAT);
       }
       bpoly = geomFact.createPolygon(coords.toArray(new Coordinate[] {}));
+      if (!utils.isWithin(bpoly)) {
+        throw new NotFoundException(ExceptionMessages.BOUNDARY_NOT_IN_DATA_EXTRACT);
+      }
       geometryList.add(bpoly);
       processingData.setBoundaryList(geometryList);
       processingData.setRequestGeom(bpoly);

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -50,8 +50,12 @@ public class PostControllerTest {
     }
   }
 
+  /*
+   * test geometries lying outside the underlying data-extract polygon
+   */
+
   @Test
-  public void providedBoundaryOutsideUnderlyingDataExtractpolygonTest() {
+  public void providedBcirclesOutsideUnderlyingDataExtractPolygonTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add("bcircles", "8.457261,49.488483,100");
@@ -60,6 +64,16 @@ public class PostControllerTest {
     assertEquals(404, response.getBody().get("status").asInt());
   }
 
+  @Test
+  public void providedBpolysOutsideUnderlyingDataExtractPolygonTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("bpolys",
+        "8.422684,49.471910,8.422694,49.471980|8.426363,49.473583,8.426373,49.473593|8.422684,49.471910,8.422694,49.471980");
+    ResponseEntity<JsonNode> response =
+        restTemplate.postForEntity(server + port + "/elements/perimeter", map, JsonNode.class);
+    assertEquals(404, response.getBody().get("status").asInt());
+  }
 
   /*
    * false parameter tests

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -58,21 +58,27 @@ public class PostControllerTest {
   public void providedBcirclesOutsideUnderlyingDataExtractPolygonTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    String message = "The provided boundary parameter "
+        + "does not lie completely within the underlying data-extract polygon.";
     map.add("bcircles", "8.457261,49.488483,100");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/users/count", map, JsonNode.class);
     assertEquals(404, response.getBody().get("status").asInt());
+    assertEquals(message, response.getBody().get("message").asText());
   }
 
   @Test
   public void providedBpolysOutsideUnderlyingDataExtractPolygonTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    String message = "The provided boundary parameter "
+        + "does not lie completely within the underlying data-extract polygon.";
     map.add("bpolys", "8.422684,49.471910,8.422694,49.471980|8.426363,49.473583,8.426373,49.473593"
         + "|8.422684,49.471910,8.422694,49.471980");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/perimeter", map, JsonNode.class);
     assertEquals(404, response.getBody().get("status").asInt());
+    assertEquals(message, response.getBody().get("message").asText());
   }
 
   /*

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -68,8 +68,8 @@ public class PostControllerTest {
   public void providedBpolysOutsideUnderlyingDataExtractPolygonTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    map.add("bpolys",
-        "8.422684,49.471910,8.422694,49.471980|8.426363,49.473583,8.426373,49.473593|8.422684,49.471910,8.422694,49.471980");
+    map.add("bpolys", "8.422684,49.471910,8.422694,49.471980|8.426363,49.473583,8.426373,49.473593"
+        + "|8.422684,49.471910,8.422694,49.471980");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/perimeter", map, JsonNode.class);
     assertEquals(404, response.getBody().get("status").asInt());

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -50,6 +50,17 @@ public class PostControllerTest {
     }
   }
 
+  @Test
+  public void providedBoundaryOutsideUnderlyingDataExtractpolygonTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("bcircles", "8.457261,49.488483,100");
+    ResponseEntity<JsonNode> response =
+        restTemplate.postForEntity(server + port + "/users/count", map, JsonNode.class);
+    assertEquals(404, response.getBody().get("status").asInt());
+  }
+
+
   /*
    * false parameter tests
    */


### PR DESCRIPTION
### Description
Use a more generic message in case of wrong `time` parameter value for `full-history` and `contributions` extraction endpoints.
Throw an exception for all cases in which the given values for the `bpolys` and `bcircles` boundaries don't lie completely within the underlying data-extract polygon.

### Corresponding issue
Closes #201 and #208

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have added sufficient unit and API tests
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
