### PR TITLE
Catch and throw new `BadRequestException` in cases of invalid `bpolys` boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Bug Fixes
 
+* fix wrong thrown exceptions in case of invalid `bpolys` boundary ([#214])
 * fix not thrown exception in case of `bpolys` and `bcircles` boundaries not lying completely within the underlying data-extract polygon ([#201])
 
 ### Other Changes
@@ -13,7 +14,7 @@ Changelog
 
 [#201]: https://github.com/GIScience/ohsome-api/issues/201
 [#208]: https://github.com/GIScience/ohsome-api/issues/208
-
+[#214]: https://github.com/GIScience/ohsome-api/issues/214
 
 ## 1.5.0
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -14,6 +14,8 @@ public class ExceptionMessages {
           + "remember to follow the format, where you separate every coordinate with a comma, "
           + "each boundary object with a pipe-sign "
           + "and add optional custom ids to every first coordinate with a colon.";
+  public static final String BPOLYS_PARAM_GEOMETRY =
+      "The defined bpolys parameter contains some invalid geometry: ";
   public static final String BOUNDARY_IDS_FORMAT =
       "One or more boundary object(s) have a custom id "
           + "(or at least a colon), whereas other(s) don't. You can either set custom ids for all "

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/GeometryBuilder.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/GeometryBuilder.java
@@ -165,10 +165,10 @@ public class GeometryBuilder {
           coords.add(
               new Coordinate(Double.parseDouble(bpolys[i]), Double.parseDouble(bpolys[i + 1])));
         }
-      } catch (NumberFormatException e) {
+        bpoly = geomFact.createPolygon(coords.toArray(new Coordinate[] {}));
+      } catch (IllegalArgumentException e) {
         throw new BadRequestException(ExceptionMessages.BPOLYS_FORMAT);
       }
-      bpoly = geomFact.createPolygon(coords.toArray(new Coordinate[] {}));
       if (!utils.isWithin(bpoly)) {
         throw new NotFoundException(ExceptionMessages.BOUNDARY_NOT_IN_DATA_EXTRACT);
       }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -214,7 +214,7 @@ public class InputProcessor {
       try {
         mapRed = mapRed.areaOfInterest((Geometry & Polygonal) boundary);
       } catch (TopologyException e) {
-        throw new BadRequestException("Invalid geometry: " + e.getMessage());
+        throw new BadRequestException(ExceptionMessages.BPOLYS_PARAM_GEOMETRY + e.getMessage());
       }
     }
     processShowMetadata(showMetadata);

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -41,6 +41,7 @@ import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
 import org.heigit.ohsome.ohsomeapi.utils.RequestUtils;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygonal;
+import org.locationtech.jts.geom.TopologyException;
 import org.wololo.jts2geojson.GeoJSONWriter;
 
 /**
@@ -192,9 +193,7 @@ public class InputProcessor {
         dbIgnite.computeMode(computeMode);
       }
     }
-
     DbConnData.db.timeout(timeout);
-
     if (isSnapshot) {
       if (DbConnData.keytables == null) {
         mapRed = OSMEntitySnapshotView.on(DbConnData.db);
@@ -212,11 +211,13 @@ public class InputProcessor {
       mapRed =
           mapRed.areaOfInterest(OSHDBGeometryBuilder.boundingBoxOf(boundary.getEnvelopeInternal()));
     } else {
-      mapRed = mapRed.areaOfInterest((Geometry & Polygonal) boundary);
+      try {
+        mapRed = mapRed.areaOfInterest((Geometry & Polygonal) boundary);
+      } catch (TopologyException e) {
+        throw new BadRequestException("Invalid geometry: " + e.getMessage());
+      }
     }
-
     processShowMetadata(showMetadata);
-
     checkFormat(processingData.getFormat());
     if ("geojson".equalsIgnoreCase(processingData.getFormat())) {
       GeoJSONWriter writer = new GeoJSONWriter();

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.ohsomeapi.controller;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -14,6 +15,7 @@ import java.util.Spliterators;
 import java.util.stream.StreamSupport;
 import org.apache.commons.csv.CSVRecord;
 import org.heigit.ohsome.ohsomeapi.Application;
+import org.heigit.ohsome.ohsomeapi.exception.ExceptionMessages;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -89,28 +91,24 @@ public class PostControllerTest {
   public void oneCoordinatesPairTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    String message = "The bpolys parameter must contain double-parseable values in form of lon/lat"
-        + " coordinate pairs.";
     map.add("bpolys", "8.65821,49.41129");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());
-    assertEquals(message, response.getBody().get("message").asText());
+    assertEquals(ExceptionMessages.BPOLYS_FORMAT, response.getBody().get("message").asText());
   }
 
   @Test
   public void nonNodedLinestringsIntersectionTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    String message = "Invalid geometry: found non-noded intersection between LINESTRING "
-        + "( 8.696384 49.401269, 8.674739 49.401869 ) and LINESTRING ( 8.681818 49.404774, "
-        + "8.695483 49.400794 ) [ (8.693585810865496, 49.401346565880374, NaN) ]";
     map.add("bpolys", "8.695483,49.400794,8.696384,49.401269|8.674739,49.401869,8.681818,49.404774"
         + "|8.695483,49.400794,8.696384,49.401269");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());
-    assertEquals(message, response.getBody().get("message").asText());
+    assertTrue(response.getBody().get("message").asText()
+        .contains(ExceptionMessages.BPOLYS_PARAM_GEOMETRY));
   }
 
   /*

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -80,7 +80,39 @@ public class PostControllerTest {
     assertEquals(404, response.getBody().get("status").asInt());
     assertEquals(message, response.getBody().get("message").asText());
   }
+  
+  /*
+   * test request with invalid bpolys boundary
+   */
 
+  @Test
+  public void oneCoordinatesPairTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    String message = "The bpolys parameter must contain double-parseable values in form of lon/lat"
+        + " coordinate pairs.";;
+    map.add("bpolys", "8.65821,49.41129");
+    ResponseEntity<JsonNode> response =
+        restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
+    assertEquals(400, response.getBody().get("status").asInt());
+    assertEquals(message, response.getBody().get("message").asText());
+  }
+  
+  @Test
+  public void nonNodedLinestringsIntersectionTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    String message = "Invalid geometry: found non-noded intersection between LINESTRING "
+        + "( 8.696384 49.401269, 8.674739 49.401869 ) and LINESTRING ( 8.681818 49.404774, "
+        + "8.695483 49.400794 ) [ (8.693585810865496, 49.401346565880374, NaN) ]";
+    map.add("bpolys", "8.695483,49.400794,8.696384,49.401269|8.674739,49.401869,8.681818,49.404774"
+        + "|8.695483,49.400794,8.696384,49.401269");
+    ResponseEntity<JsonNode> response =
+        restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
+    assertEquals(400, response.getBody().get("status").asInt());
+    assertEquals(message, response.getBody().get("message").asText());
+  }
+  
   /*
    * false parameter tests
    */

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -80,7 +80,7 @@ public class PostControllerTest {
     assertEquals(404, response.getBody().get("status").asInt());
     assertEquals(message, response.getBody().get("message").asText());
   }
-  
+
   /*
    * test request with invalid bpolys boundary
    */
@@ -90,14 +90,14 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     String message = "The bpolys parameter must contain double-parseable values in form of lon/lat"
-        + " coordinate pairs.";;
+        + " coordinate pairs.";
     map.add("bpolys", "8.65821,49.41129");
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/count", map, JsonNode.class);
     assertEquals(400, response.getBody().get("status").asInt());
     assertEquals(message, response.getBody().get("message").asText());
   }
-  
+
   @Test
   public void nonNodedLinestringsIntersectionTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
@@ -112,7 +112,7 @@ public class PostControllerTest {
     assertEquals(400, response.getBody().get("status").asInt());
     assertEquals(message, response.getBody().get("message").asText());
   }
-  
+
   /*
    * false parameter tests
    */


### PR DESCRIPTION
### Description
Catches and throws a new `BadRequestException` in cases of an invalid geometry given through the `bpolys` parameter.

### Corresponding issue
Closes #214 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have added sufficient unit and API tests
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)