### PR TITLE
upgrade to OSHDB 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changelog
 
 ### Other Changes
 
-* upgrade to OSHDB version 0.7.0 – note that oshdb database files from the previous version are not compatible with this version anymore, you have to either [redownload](https://downloads.ohsome.org/OSHDB/v0.7/) or [recreate](https://github.com/GIScience/oshdb/blob/0.7/oshdb-etl/README.md) them from scratch ([#222])
+* upgrade to OSHDB version 0.7.1 – note that OSHDB database files from the previous version are not compatible with the OSHDB version 0.7 anymore, so you have to either [redownload](https://downloads.ohsome.org/OSHDB/v0.7/) or [recreate](https://github.com/GIScience/oshdb/blob/0.7/oshdb-etl/README.md) them from scratch ([#222], [#225])
 * adapt error message for contributions extration endpoint in case of wrong `time` parameter value ([#208])
 
 [#161]: https://github.com/GIScience/ohsome-api/pull/161
@@ -22,6 +22,7 @@ Changelog
 [#208]: https://github.com/GIScience/ohsome-api/issues/208
 [#214]: https://github.com/GIScience/ohsome-api/issues/214
 [#222]: https://github.com/GIScience/ohsome-api/pull/222
+[#225]: https://github.com/GIScience/ohsome-api/pull/225
 
 
 ## 1.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <jts2geojson.version>0.13.0</jts2geojson.version>
     <mavenjar.version>3.2.0</mavenjar.version>
     <opencsv.version>4.0</opencsv.version>
-    <oshdb.version>0.7.0</oshdb.version>
+    <oshdb.version>0.7.1</oshdb.version>
     <projectlombok.version>1.18.16</projectlombok.version>
     <sonar.sources>src/main/lombok</sonar.sources>
     <springboot.version>2.0.3.RELEASE</springboot.version>


### PR DESCRIPTION
### Description
Fixes a bug which prevented deployment of the ohsome API on an OSHDB ignite cluster.

### New or changed dependencies
- upgrade OSHDB to version 0.7.1 (from 0.7.0)

### Checklist
- ~~My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~~
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit and API tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
