### PR TITLE
fix non-unique-parameter check for post request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 1.6.0-SNAPSHOT (current master)
+## 1.7.0-SNAPSHOT (current master)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## 1.6.0-SNAPSHOT (current master)
+
+### Bug Fixes
+
+* fix bug which prevented error messages from being returned for non-unique parameters in POST requests. ([#228])
+
+[#228]: https://github.com/GIScience/ohsome-api/pull/228
+
+
 ## 1.6.0
 
 ### Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <url>https://api.ohsome.org</url>
   <description>A public Web-RESTful-API for "ohsome" OpenStreetMap history data.</description>
   <packaging>jar</packaging>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git@github.com:GIScience/ohsome-api.git</connection>

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -726,24 +724,10 @@ public class InputProcessor {
       throw new BadRequestException(
           StringSimilarity.findSimilarParameters(unexpectedParam, possibleParameters));
     }
-    if (servletRequest.getQueryString() != null) {
-      String queryString = servletRequest.getQueryString();
-      String[] queryStringArray = queryString.split("&");
-      List<String> paramsValuesList = Arrays.asList(queryStringArray);
-      List<String> paramsList = new ArrayList<>();
-      String param;
-      for (int i = 0; i < paramsValuesList.size(); i++) {
-        if (!paramsValuesList.get(i).contains("=")) {
-          paramsValuesList.set(i, paramsValuesList.get(i).concat("="));
-        }
-        param = paramsValuesList.get(i).substring(0, paramsValuesList.get(i).indexOf("="));
-        paramsList.add(param);
-      }
-      for (String parameter : paramsList) {
-        if (Collections.frequency(paramsList, parameter) > 1) {
-          throw new BadRequestException("Every parameter has to be unique. "
-              + "You can't give more than one '" + parameter + "' parameter.");
-        }
+    for (var parameter : servletRequest.getParameterMap().entrySet()) {
+      if (parameter.getValue().length != 1) {
+        throw new BadRequestException("Every parameter has to be unique. "
+            + "You can't give more than one '" + parameter + "' parameter.");
       }
     }
   }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -1328,4 +1328,15 @@ public class GetControllerTest {
         restTemplate.getForEntity(server + port + "/users/count?", JsonNode.class);
     assertEquals(null, response.getBody().get("error"));
   }
+
+  @Test
+  public void getRequestNonUniqueParam() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response =
+        restTemplate.getForEntity(
+            server + port + "/users/count?bboxes=8.67452,49.40961,8.70392,49.41823&"
+                + "time=2014-01-01/2015-01-01&filter=type:node&filter=type:way",
+            JsonNode.class);
+    assertEquals(400, response.getStatusCode().value());
+  }
 }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -1225,4 +1225,17 @@ public class PostControllerTest {
     assertEquals(85.45, response.getBody().get("result").get(0).get("value").asDouble(),
         deltaPercentage);
   }
+
+  @Test
+  public void postRequestNonUniqueParam() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("bboxes", "8.69282,49.40766,8.71673,49.4133");
+    map.add("time", "2018-01-01,2019-01-01");
+    map.add("filter", "type:node");
+    map.add("filter", "type:way");
+    ResponseEntity<JsonNode> response = restTemplate
+        .postForEntity(server + port + "/contributions/count/density", map, JsonNode.class);
+    assertEquals(400, response.getStatusCode().value());
+  }
 }


### PR DESCRIPTION
### Description

Fixes a bug where no error is returned for non-unique request parameters in POST requests (see #12).

To reproduce the issue using javascript in a browser (note the duplicate `filter` parameter in both request below):

```javascript
console.log((await fetch("https://api.ohsome.org/v1/elements/count?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type%3Anode&filter=type%3Away&format=json&time=2014-01-01%2F2017-01-01%2FP1Y", { "method": "GET" })).status);
// GET request -> returns 400

console.log((await fetch("https://api.ohsome.org/v1/elements/count", {
    "headers": {
        "content-type": "application/x-www-form-urlencoded"
    },
    "method": "POST",
    "body": "bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type%3Anode&filter=type%3Away&format=json&time=2014-01-01%2F2017-01-01%2FP1Y"
})).status);
// POST request -> returns 200
```
 
This PR also simplifies the implementation for GET requests as well and add tests.

### Corresponding issue
See #12

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
