### PR TITLE
Error message for requests without defined parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### New Features
 
 * add `contributions/count[/density]/groupBy/boundary` endpoints to fetch contribution counts/densities grouped by boundary ([#217])
-* add an error message for requests without defined parameters. [#233]
+* add an error message for requests without defined parameters ([#233])
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### New Features
 
 * add `contributions/count[/density]/groupBy/boundary` endpoints to fetch contribution counts/densities grouped by boundary ([#217])
+* add error message in cases of queries without defined parameter [#233]
 
 ### Bug Fixes
 
@@ -15,7 +16,7 @@ Changelog
 [#217]: https://github.com/GIScience/ohsome-api/issues/217
 [#228]: https://github.com/GIScience/ohsome-api/pull/228
 [#230]: https://github.com/GIScience/ohsome-api/pull/230
-
+[#233]: https://github.com/GIScience/ohsome-api/issues/227
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### New Features
 
 * add `contributions/count[/density]/groupBy/boundary` endpoints to fetch contribution counts/densities grouped by boundary ([#217])
-* add an error message for requests without defined parameters ([#233])
+* add an error message for requests without defined parameters ([#227])
 
 ### Bug Fixes
 
@@ -14,9 +14,9 @@ Changelog
 * fix a regression causing `…/groupBy/boundary` to crash when used with a geometry type filter using the (deprecated) types/keys/values parameter syntax ([#230])
 
 [#217]: https://github.com/GIScience/ohsome-api/issues/217
+[#227]: https://github.com/GIScience/ohsome-api/issues/227
 [#228]: https://github.com/GIScience/ohsome-api/pull/228
 [#230]: https://github.com/GIScience/ohsome-api/pull/230
-[#233]: https://github.com/GIScience/ohsome-api/issues/227
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### New Features
 
 * add `contributions/count[/density]/groupBy/boundary` endpoints to fetch contribution counts/densities grouped by boundary ([#217])
-* add error message in cases of queries without defined parameter [#233]
+* add an error message for requests without defined parameters. [#233]
 
 ### Bug Fixes
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -35,6 +35,8 @@ public class ExceptionMessages {
       "You need to give one groupByKeys parameter, if you want to use groupBy/key.";
   public static final String KEYS_VALUES_RATIO_INVALID = "There cannot be more input values in the "
       + "values|values2 than in the keys|keys2 parameter, as values_n must fit to keys_n.";
+  public static final String NO_DEFINED_PARAMS = "The query did not specify any parameter. "
+          + "Please remember: ";
   public static final String NO_BOUNDARY =
       "You need to define one of the boundary parameters (bboxes, bcircles, bpolys).";
   public static final String PAYLOAD_TOO_LARGE =

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -36,7 +36,7 @@ public class ExceptionMessages {
   public static final String KEYS_VALUES_RATIO_INVALID = "There cannot be more input values in the "
       + "values|values2 than in the keys|keys2 parameter, as values_n must fit to keys_n.";
   public static final String NO_DEFINED_PARAMS = "The query did not specify any parameter. "
-          + "Please remember: ";
+          + "Please remember: " + ExceptionMessages.NO_BOUNDARY;
   public static final String NO_BOUNDARY =
       "You need to define one of the boundary parameters (bboxes, bcircles, bpolys).";
   public static final String PAYLOAD_TOO_LARGE =

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -718,8 +718,7 @@ public class InputProcessor {
    */
   private void checkParameters(HttpServletRequest servletRequest) {
     if (servletRequest.getParameterMap().isEmpty()) {
-      throw new BadRequestException(ExceptionMessages.NO_DEFINED_PARAMS
-          + ExceptionMessages.NO_BOUNDARY);
+      throw new BadRequestException(ExceptionMessages.NO_DEFINED_PARAMS);
     }
     List<String> possibleParameters = ResourceParameters.getResourceSpecificParams(servletRequest);
     List<String> unexpectedParams =

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -718,8 +718,8 @@ public class InputProcessor {
    */
   private void checkParameters(HttpServletRequest servletRequest) {
     if (servletRequest.getParameterMap().isEmpty()) {
-      throw new BadRequestException("The query did not specify any parameter. Please remember: "
-              + ExceptionMessages.NO_BOUNDARY);
+      throw new BadRequestException(ExceptionMessages.NO_DEFINED_PARAMS
+          + ExceptionMessages.NO_BOUNDARY);
     }
     List<String> possibleParameters = ResourceParameters.getResourceSpecificParams(servletRequest);
     List<String> unexpectedParams =

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -709,13 +709,18 @@ public class InputProcessor {
   }
 
   /**
-   * Checks, if there are false or repeated parameters in the request. It suggests possible
-   * parameters based on fuzzy matching scores.
+   * Checks, if the request does not specify any parameter or if it specifies false or repeated
+   * parameters. In case of false or repeated parameters, it suggests possible parameters based on
+   * fuzzy matching scores.
    *
-   * @throws BadRequestException in case of invalid parameter or if a parameter is given more than
-   *         once
+   * @throws BadRequestException in case of no parameters, invalid parameters or if parameters are
+   *     given more than once.
    */
   private void checkParameters(HttpServletRequest servletRequest) {
+    if (servletRequest.getParameterMap().isEmpty()) {
+      throw new BadRequestException("The query did not specify any parameter. Please remember: "
+              + ExceptionMessages.NO_BOUNDARY);
+    }
     List<String> possibleParameters = ResourceParameters.getResourceSpecificParams(servletRequest);
     List<String> unexpectedParams =
         ResourceParameters.checkUnexpectedParams(servletRequest, possibleParameters);

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -119,10 +119,8 @@ public class PostControllerTest {
   public void queryWithoutParametersTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response =
-            restTemplate.postForEntity(server + port + "/elements/perimeter", null,
-                    JsonNode.class);
-    String errorMessage = "The query did not specify any parameter. Please remember: "
-            + ExceptionMessages.NO_BOUNDARY;
+        restTemplate.postForEntity(server + port + "/elements/perimeter", null, JsonNode.class);
+    String errorMessage = ExceptionMessages.NO_DEFINED_PARAMS + ExceptionMessages.NO_BOUNDARY;
     assertEquals(errorMessage, response.getBody().get("message").asText());
   }
 

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -112,8 +112,20 @@ public class PostControllerTest {
   }
 
   /*
-   * false parameter tests
+   * false parameter and no parameters tests
    */
+
+  @Test
+  public void queryWithoutParametersTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response =
+            restTemplate.postForEntity(server + port + "/elements/perimeter", null,
+                    JsonNode.class);
+    String errorMessage = "The query did not specify any parameter. Please remember: "
+            + ExceptionMessages.NO_BOUNDARY;
+    System.out.println("rosariotest " + response.getBody().get("message").asText());
+    assertEquals(errorMessage, response.getBody().get("message").asText());
+  }
 
   @Test
   public void postGeneralResourceWithFalseParameterTest() {

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -120,8 +120,7 @@ public class PostControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response =
         restTemplate.postForEntity(server + port + "/elements/perimeter", null, JsonNode.class);
-    String errorMessage = ExceptionMessages.NO_DEFINED_PARAMS + ExceptionMessages.NO_BOUNDARY;
-    assertEquals(errorMessage, response.getBody().get("message").asText());
+    assertEquals(ExceptionMessages.NO_DEFINED_PARAMS, response.getBody().get("message").asText());
   }
 
   @Test

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -123,7 +123,6 @@ public class PostControllerTest {
                     JsonNode.class);
     String errorMessage = "The query did not specify any parameter. Please remember: "
             + ExceptionMessages.NO_BOUNDARY;
-    System.out.println("rosariotest " + response.getBody().get("message").asText());
     assertEquals(errorMessage, response.getBody().get("message").asText());
   }
 


### PR DESCRIPTION
It gives back an error message in the case of queries without defined parameters.

### Corresponding issue
Closes #227 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have added sufficient unit and API tests
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)