### PR TITLE
upgrade to oshdb version 0.7.2 + release as 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Changelog
 [#228]: https://github.com/GIScience/ohsome-api/pull/228
 [#230]: https://github.com/GIScience/ohsome-api/pull/230
 
+
+## 1.6.1
+
+* upgrade OSHDB to version [`0.7.2`](https://github.com/GIScience/oshdb/releases/tag/0.7.2), with bugfixes for not working `length:` and `area:` filters on ignite and improved job canceling ([#237])
+
+[#237]: https://github.com/GIScience/ohsome-api/pull/237
+
+
 ## 1.6.0
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The ohsome API is a generic web API for in-depth analysis of OpenStreetMap (OSM) data with a focus on its history. It allows to get aggregated statistics about the evolution of OSM data itself and about the contributors behind the data. Furthermore, data extraction methods are provided to access the historic development of individual OSM features.
 
-The functionalities of the ohsome API can be accessed via HTTP requests. As a basis underneath serves the [OSHDB API](https://github.com/GIScience/oshdb). The current stable version is [v1.6.0](https://github.com/GIScience/ohsome-api/releases/tag/1.6.0). Developed and maintained by [HeiGIT](https://heigit.org/).
+The functionalities of the ohsome API can be accessed via HTTP requests. As a basis underneath serves the [OSHDB API](https://github.com/GIScience/oshdb). The current stable version is [v1.6.1](https://github.com/GIScience/ohsome-api/releases/tag/1.6.1). Developed and maintained by [HeiGIT](https://heigit.org/).
 
 ## Using the ohsome API
 
@@ -39,7 +39,7 @@ Here you see an example response giving the length of residential roads for a bo
         "url": "https://ohsome.org/copyrights",
         "text": "© OpenStreetMap contributors"
     },
-    "apiVersion": "1.6.0",
+    "apiVersion": "1.6.1",
     "metadata": {
         "executionTime": 858,
         "description": "Total length of items in meters.",
@@ -108,8 +108,8 @@ These instructions will get you a copy of the project up and running on your loc
 2. move to your Maven project directory in a shell (e.g. Windows PowerShell)
 3. enter the command `mvn -DskipTests=true package` to build the project (if you want to build it running the integrated tests too, look at the section [Testing](#testing))
 4. to run the jar file enter the following (if no additional keytables file is given, you can assume that it is included):
-    * keytables included: `java -jar target/ohsome-api-1.6.0.jar --database.db=C:/path-to-your-data/ba-wue.oshdb`
-    * keytables not included: `java -jar target/ohsome-api-1.6.0.jar --database.db=C:/path-to-your-data/ba-wue.oshdb --database.keytables=C:/path-to-your-keytablesFile/keytables`
+    * keytables included: `java -jar target/ohsome-api-1.6.1.jar --database.db=C:/path-to-your-data/ba-wue.oshdb`
+    * keytables not included: `java -jar target/ohsome-api-1.6.1.jar --database.db=C:/path-to-your-data/ba-wue.oshdb --database.keytables=C:/path-to-your-keytablesFile/keytables`
 
 Now you should have a running local API, which is ready for receiving requests under *http://localhost:8080/*.
 <br>To check if it is running properly, you should be able to visit the swagger documentation under *http://localhost:8080/swagger-ui.html*.

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -65,7 +65,7 @@ How big is the area of farmland in the region Rhein-Neckar?
          "url" : "https://ohsome.org/copyrights",
          "text" : "© OpenStreetMap contributors"
        },
-       "apiVersion" : "1.6.0",
+       "apiVersion" : "1.6.1",
        "result" : [ {
          "timestamp" : "2014-01-01T00:00:00Z",
          "value" : 1.020940258E7
@@ -79,7 +79,7 @@ How big is the area of farmland in the region Rhein-Neckar?
          "url" : "https://ohsome.org/copyrights",
          "text" : "© OpenStreetMap contributors"
        },
-       "apiVersion" : "1.6.0",
+       "apiVersion" : "1.6.1",
        "result" : [ {
          "timestamp" : "2014-01-01T00:00:00Z",
          "value" : 1.020940258E7
@@ -93,7 +93,7 @@ How big is the area of farmland in the region Rhein-Neckar?
          "url" : "https://ohsome.org/copyrights",
          "text" : "© OpenStreetMap contributors"
        },
-       "apiVersion" : "1.6.0",
+       "apiVersion" : "1.6.1",
        "result" : [ {
          "timestamp" : "2014-01-01T00:00:00Z",
          "value" : 10209402.58
@@ -107,7 +107,7 @@ How big is the area of farmland in the region Rhein-Neckar?
          "url" : "https://ohsome.org/copyrights",
          "text" : "© OpenStreetMap contributors"
        },
-       "apiVersion" : "1.6.0",
+       "apiVersion" : "1.6.1",
        "result" : [ {
          "timestamp" : "2014-01-01T00:00:00Z",
          "value" : 1.020940258E7
@@ -160,7 +160,7 @@ What is the density of restaurants with wheelchair access in Heidelberg?
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "result" : [ {
                  "timestamp" : "2019-05-07T00:00:00Z",
                  "value" : 0.79
@@ -174,7 +174,7 @@ What is the density of restaurants with wheelchair access in Heidelberg?
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "result" : [ {
                  "timestamp" : "2019-05-07T00:00:00Z",
                  "value" : 0.79
@@ -188,7 +188,7 @@ What is the density of restaurants with wheelchair access in Heidelberg?
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "result" : [ {
                  "timestamp" : "2019-05-07T00:00:00Z",
                  "value" : 0.79
@@ -202,7 +202,7 @@ What is the density of restaurants with wheelchair access in Heidelberg?
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "result" : [ {
                  "timestamp" : "2019-05-07T00:00:00Z",
                  "value" : 0.79
@@ -262,7 +262,7 @@ How many oneway streets exist within living_street streets in Heidelberg over ti
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "ratioResult" : [ {
                  "timestamp" : "2016-01-01T00:00:00Z",
                  "value" : 28660.519999999997,
@@ -288,7 +288,7 @@ How many oneway streets exist within living_street streets in Heidelberg over ti
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "ratioResult" : [ {
                  "timestamp" : "2016-01-01T00:00:00Z",
                  "value" : 28660.519999999997,
@@ -314,7 +314,7 @@ How many oneway streets exist within living_street streets in Heidelberg over ti
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "ratioResult" : [ {
                  "timestamp" : "2016-01-01T00:00:00Z",
                  "value" : 28660.519999999997,
@@ -340,7 +340,7 @@ How many oneway streets exist within living_street streets in Heidelberg over ti
                  "url" : "https://ohsome.org/copyrights",
                  "text" : "© OpenStreetMap contributors"
                },
-               "apiVersion" : "1.6.0",
+               "apiVersion" : "1.6.1",
                "ratioResult" : [ {
                  "timestamp" : "2016-01-01T00:00:00Z",
                  "value" : 28660.519999999997,
@@ -412,7 +412,7 @@ How often information about the roof of buildings is present?
                 "url" : "https://ohsome.org/copyrights",
                 "text" : "© OpenStreetMap contributors"
               },
-              "apiVersion" : "1.6.0",
+              "apiVersion" : "1.6.1",
               "groupByResult" : [ {
                 "result" : [ {
                   "timestamp" : "2018-01-01T00:00:00Z",
@@ -441,7 +441,7 @@ How often information about the roof of buildings is present?
                 "url" : "https://ohsome.org/copyrights",
                 "text" : "© OpenStreetMap contributors"
               },
-              "apiVersion" : "1.6.0",
+              "apiVersion" : "1.6.1",
               "groupByResult" : [ {
                 "result" : [ {
                   "timestamp" : "2018-01-01T00:00:00Z",
@@ -470,7 +470,7 @@ How often information about the roof of buildings is present?
                 "url" : "https://ohsome.org/copyrights",
                 "text" : "© OpenStreetMap contributors"
               },
-              "apiVersion" : "1.6.0",
+              "apiVersion" : "1.6.1",
               "groupByResult" : [ {
                 "result" : [ {
                   "timestamp" : "2018-01-01T00:00:00Z",
@@ -499,7 +499,7 @@ How often information about the roof of buildings is present?
                 "url" : "https://ohsome.org/copyrights",
                 "text" : "© OpenStreetMap contributors"
               },
-              "apiVersion" : "1.6.0",
+              "apiVersion" : "1.6.1",
               "groupByResult" : [ {
                 "result" : [ {
                   "timestamp" : "2018-01-01T00:00:00Z",
@@ -582,7 +582,7 @@ Compare length of different types of streets for two or more regions.
                "url" : "https://ohsome.org/copyrights",
                "text" : "© OpenStreetMap contributors"
              },
-             "apiVersion" : "1.6.0",
+             "apiVersion" : "1.6.1",
              "groupByResult" : [ {
                "result" : [ {
                  "timestamp" : "2018-01-01T00:00:00Z",
@@ -641,7 +641,7 @@ Compare length of different types of streets for two or more regions.
                "url" : "https://ohsome.org/copyrights",
                "text" : "© OpenStreetMap contributors"
              },
-             "apiVersion" : "1.6.0",
+             "apiVersion" : "1.6.1",
              "groupByResult" : [ {
                "result" : [ {
                  "timestamp" : "2018-01-01T00:00:00Z",
@@ -700,7 +700,7 @@ Compare length of different types of streets for two or more regions.
                "url" : "https://ohsome.org/copyrights",
                "text" : "© OpenStreetMap contributors"
              },
-             "apiVersion" : "1.6.0",
+             "apiVersion" : "1.6.1",
              "groupByResult" : [ {
                "result" : [ {
                  "timestamp" : "2018-01-01T00:00:00Z",
@@ -759,7 +759,7 @@ Compare length of different types of streets for two or more regions.
                "url" : "https://ohsome.org/copyrights",
                "text" : "© OpenStreetMap contributors"
              },
-             "apiVersion" : "1.6.0",
+             "apiVersion" : "1.6.1",
              "groupByResult" : [ {
                "result" : [ {
                  "timestamp" : "2018-01-01T00:00:00Z",
@@ -883,7 +883,7 @@ Show number of users editing buildings before, during and after Nepal earthquake
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "result" : [ {
           "fromTimestamp" : "2015-03-01T00:00:00Z",
           "toTimestamp" : "2015-04-01T00:00:00Z",
@@ -914,7 +914,7 @@ Show number of users editing buildings before, during and after Nepal earthquake
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "result" : [ {
           "fromTimestamp" : "2015-03-01T00:00:00Z",
           "toTimestamp" : "2015-04-01T00:00:00Z",
@@ -945,7 +945,7 @@ Show number of users editing buildings before, during and after Nepal earthquake
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "result" : [ {
           "fromTimestamp" : "2015-03-01T00:00:00Z",
           "toTimestamp" : "2015-04-01T00:00:00Z",
@@ -976,7 +976,7 @@ Show number of users editing buildings before, during and after Nepal earthquake
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "result" : [ {
           "fromTimestamp" : "2015-03-01T00:00:00Z",
           "toTimestamp" : "2015-04-01T00:00:00Z",
@@ -1062,7 +1062,7 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2010-01-01T00:00:00Z",
@@ -1079,7 +1079,7 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2010-01-01T00:00:00Z",
@@ -1096,7 +1096,7 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2010-01-01T00:00:00Z",
@@ -1113,7 +1113,7 @@ Number of contributions to the building 'Stadthalle Heidelberg' between 2010 and
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2010-01-01T00:00:00Z",
@@ -1166,7 +1166,7 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1183,7 +1183,7 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1200,7 +1200,7 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1217,7 +1217,7 @@ Density of contributions to shops within the oldtown area of Heidelberg between 
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1270,7 +1270,7 @@ Number of the latest contributions to residential buildings with a geometry chan
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2014-01-01T00:00:00Z",
@@ -1287,7 +1287,7 @@ Number of the latest contributions to residential buildings with a geometry chan
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2014-01-01T00:00:00Z",
@@ -1304,7 +1304,7 @@ Number of the latest contributions to residential buildings with a geometry chan
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2014-01-01T00:00:00Z",
@@ -1321,7 +1321,7 @@ Number of the latest contributions to residential buildings with a geometry chan
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2014-01-01T00:00:00Z",
@@ -1374,7 +1374,7 @@ Density of the latest contributions with a geometry change to shops within the o
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1391,7 +1391,7 @@ Density of the latest contributions with a geometry change to shops within the o
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1408,7 +1408,7 @@ Density of the latest contributions with a geometry change to shops within the o
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1425,7 +1425,7 @@ Density of the latest contributions with a geometry change to shops within the o
 	    "url" : "https://ohsome.org/copyrights",
 	    "text" : "© OpenStreetMap contributors"
 	  },
-	  "apiVersion" : "1.6.0",
+	  "apiVersion" : "1.6.1",
 	  "result" : [
 	    {
 	      "fromTimestamp" : "2012-01-01T00:00:00Z",
@@ -1824,7 +1824,7 @@ Extract the modifications of the blown up tower of the heidelberg castle over ti
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "type" : "FeatureCollection",
         "features" : [{
           "type" : "Feature",
@@ -1862,7 +1862,7 @@ Extract the modifications of the blown up tower of the heidelberg castle over ti
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "type" : "FeatureCollection",
         "features" : [{
           "type" : "Feature",
@@ -1900,7 +1900,7 @@ Extract the modifications of the blown up tower of the heidelberg castle over ti
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "type" : "FeatureCollection",
         "features" : [{
           "type" : "Feature",
@@ -1938,7 +1938,7 @@ Extract the modifications of the blown up tower of the heidelberg castle over ti
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "type" : "FeatureCollection",
         "features" : [{
           "type" : "Feature",
@@ -2023,7 +2023,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6720,49.3988,8.7026,49.4274&filter=amenity=pharmacy%20and%20opening_hours=*%20and%20type:node&time=2020-02-01,2020-06-29&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2100,7 +2100,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6720,49.3988,8.7026,49.4274&filter=amenity=pharmacy%20and%20opening_hours=*%20and%20type:node&time=2020-02-01,2020-06-29&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2177,7 +2177,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6720,49.3988,8.7026,49.4274&filter=amenity=pharmacy%20and%20opening_hours=*%20and%20type:node&time=2020-02-01,2020-06-29&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2254,7 +2254,7 @@ Get the changes of pharmacies with opening hours in a certain area of Heidelberg
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6720,49.3988,8.7026,49.4274&filter=amenity=pharmacy%20and%20opening_hours=*%20and%20type:node&time=2020-02-01,2020-06-29&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2375,7 +2375,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6644159,49.401099,8.6663353,49.4027195&filter=landuse=construction%20and%20type:way&time=2020-06-29,2014-07-01&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2424,7 +2424,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6644159,49.401099,8.6663353,49.4027195&filter=landuse=construction%20and%20type:way&time=2020-06-29,2014-07-01&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2473,7 +2473,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6644159,49.401099,8.6663353,49.4027195&filter=landuse=construction%20and%20type:way&time=2020-06-29,2014-07-01&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2522,7 +2522,7 @@ Get the latest change of constructions in a certain area of the Bahnstadt in Hei
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "metadata" : {
           "description" : "Latest contributions as GeoJSON features.",
           "requestUrl" : "https://api.ohsome.org/v1/contributions/latest/geometry?bboxes=8.6644159,49.401099,8.6663353,49.4027195&filter=landuse=construction%20and%20type:way&time=2020-06-29,2014-07-01&showMetadata=yes&properties=metadata,tags&clipGeometry=false"
@@ -2605,7 +2605,7 @@ Get metadata of the underlying OSHDB data
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "timeout": 600.0,
         "extractRegion" : {
           "spatialExtent" : {
@@ -2627,7 +2627,7 @@ Get metadata of the underlying OSHDB data
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "extractRegion" : {
           "spatialExtent" : {
             "type" : "Polygon",
@@ -2648,7 +2648,7 @@ Get metadata of the underlying OSHDB data
           "url" : "https://ohsome.org/copyrights",
           "text" : "© OpenStreetMap contributors"
         },
-        "apiVersion" : "1.6.0",
+        "apiVersion" : "1.6.1",
         "extractRegion" : {
           "spatialExtent" : {
             "type" : "Polygon",

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <jts2geojson.version>0.13.0</jts2geojson.version>
     <mavenjar.version>3.2.0</mavenjar.version>
     <opencsv.version>4.0</opencsv.version>
-    <oshdb.version>0.7.1</oshdb.version>
+    <oshdb.version>0.7.2</oshdb.version>
     <projectlombok.version>1.18.16</projectlombok.version>
     <sonar.sources>src/main/lombok</sonar.sources>
     <springboot.version>2.0.3.RELEASE</springboot.version>


### PR DESCRIPTION
this includes the following two bugfixes (the second is also kind of a performance improvement/enhancement, if you ask me):

* fix a bug which causes queries using the geometry filters `length:` and `area:` to fail when executed on an ignite cluster
* fix a bug which cause ComputeJobs to keep processing for a while despite they are already canceled
