### PR TITLE
exclude log4j-api dependency from spring-boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Changelog
 [#230]: https://github.com/GIScience/ohsome-api/pull/230
 
 
+## 1.6.2
+
+* remove unused `log4j-api` dependency ([#251])
+
+[#251]: https://github.com/GIScience/ohsome-api/pull/251
+
+
 ## 1.6.1
 
 * upgrade OSHDB to version [`0.7.2`](https://github.com/GIScience/oshdb/releases/tag/0.7.2), with bugfixes for not working `length:` and `area:` filters on ignite and improved job canceling ([#237])

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>${springboot.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### Description
`log4j` wasn't used in the ohsome API. The `log4j-api` is still loaded but not used without any configuration. Nevertheless we don't need this dependency and remove it.

### Corresponding issue
Related to [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228). More information from spring: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

### New or changed dependencies
- exclude `log4j-api` dependency from `spring-boot-starter-web`.

### Checklist
- ~[ ] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~
- ~[ ] I have commented my code~
- ~[ ] I have written javadoc (required for public methods)~
- ~[ ] I have added sufficient unit and API tests~
- ~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~[ ] I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~