### PR TITLE
add missing "s" to "contribution"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Changelog
 * add new `contributionTypes` property to `properties` parameter ([#136])
 * add new `/contributions/latest/count` and `/contributions/latest/count/density` endpoints ([#174])
 * add new `contributionType` parameter for contributions aggregation ([#174])
-* contribution extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
+* contributions extraction endpoints now return the `@contributionChangesetId` as a separate field ([#200])
 
 ### Bug Fixes
 
@@ -98,7 +98,7 @@ Changelog
 
 ## 1.4.2
 
-* contribution extraction endpoints now return the `@contributionChangesetId` as a separate field (backported from 1.5.0) ([#200])
+* contributions extraction endpoints now return the `@contributionChangesetId` as a separate field (backported from 1.5.0) ([#200])
 
 [#200]: https://github.com/GIScience/ohsome-api/issues/200
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1022,7 +1022,7 @@ Contributions Aggregation
 
 .. note:: The **/contributions/count** endpoint is a new feature that is in the experimental status, meaning it is still under internal evaluation and might be subject to changes in the upcoming minor or patch releases.
 .. note:: If the ``contributionType`` parameter is let empty, the result could contain contributions that do not effect geometries or tags.
-.. note:: In case of multiple time intervals using the **/contribution/latest** endpoints, a contribution is present in a time interval only if this is the time interval in which the latest contribution of the entity happend.
+.. note:: In case of multiple time intervals using the **/contributions/latest** endpoints, a contribution is present in a time interval only if this is the time interval in which the latest contribution of the entity happend.
 
 **Example request**:
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutor.java
@@ -57,7 +57,7 @@ public class ContributionsExecutor extends RequestExecutor {
 
   /**
    * Handler method for count calculation of the endpoints /contributions/count,
-   * /contributions/density, /contribution/latest/count, /contributions/latest/count/density
+   * /contributions/density, /contributions/latest/count, /contributions/latest/count/density
    * or /users/count.
    *
    * @param isUsersRequest the boolean value relative to the endpoint /users/count
@@ -141,7 +141,7 @@ public class ContributionsExecutor extends RequestExecutor {
 
   /**
    * Performs a count calculation for /contributions/count, /contributions/density,
-   * /contribution/latest/count or /contributions/latest/count/density.
+   * /contributions/latest/count or /contributions/latest/count/density.
    *
    * @param mapRed a MapReducer of OSM contributions
    * @param isContributionsLatest the boolean value relative to the endpoint /contributions/latest

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/output/ExtractionResponse.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/output/ExtractionResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import org.wololo.geojson.Feature;
 
 /**
- * Represents the whole GeoJSON response object for the data-extraction and contribution endpoints
+ * Represents the whole GeoJSON response object for the data-extraction and contributions endpoints
  * that always extract the data as GeoJSON, e.g. /elements/geometry or /contributions/geometry.
  */
 @JsonInclude(Include.NON_NULL)


### PR DESCRIPTION
### Description
There was at least one endpoint spelled incorrectly in the docs. Therefore all comments/docs about contributions without an "s" were corrected when appropriate.

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- ~[ ] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~
- ~[ ] I have commented my code~
- ~[ ] I have written javadoc (required for public methods)~
- ~[ ] I have added sufficient unit and API tests~
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)~
- ~[ ] I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~