### PR TITLE
document usage of changeset filter(s)

### DIFF
--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -16,59 +16,72 @@ Selectors
 .. table::
     :widths: 24 50 24
 
-    +------------------------+------------------------------------+------------------------+
-    |                        | **description**                    | **example**            |
-    +========================+====================================+========================+
-    | ``key=value``          | | matches all entities which       | ``natural=tree``       |
-    |                        | | have this exact tag              |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``key=*``              | | matches all entities which have  | ``addr:housenumber=*`` |
-    |                        | | any tag with the given key       |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``key!=value``         | | matches all entities             | ``oneway!=yes``        |
-    |                        | | which do not have                |                        |
-    |                        | | this exact tag                   |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``key!=*``             | | matches all entities which do not| ``name!=*``            |
-    |                        | | have any tag with the given key  |                        |
-    |                        | |                                  |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``key in (value list)``| | matches all entities which do    | ``highway in           |
-    |                        | | have any tag with the given key  | (residential,          |
-    |                        | | and one of the given values      | living_street)``       |
-    +------------------------+------------------------------------+------------------------+
-    | ``type:osm-type``      | | matches all entities of the      | ``type:node``          |
-    |                        | | given osm type                   |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``id:osm-id``          | | matches all entities with the    | ``id:1234``            |
-    |                        | | given osm id [1]_                |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``id:osm-type/osm-id`` | | matches the entity with the given| ``id:node/1234``       |
-    |                        | | osm type and id                  |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``id:(id list)``       | | matches all entities with the    | ``id:(1, 42, 1234)``   |
-    |                        | | given osm ids [1]_               |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``id:(id list)``       | | matches all entities with the    | ``id:(node/1, way/3)`` |
-    |                        | | given osm types and ids          |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``id:(id range)``      | | matches all entities with an id  | ``id:(1 .. 9999)``     |
-    |                        | | matching the given id range [2]_ |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``geometry:geom-type`` | | matches anything which has a     | ``geometry:polygon``   |
-    |                        | | geometry of the given type       |                        |
-    |                        | | (point, line, polygon, or other) |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``area:(from..to)``    | | matches features with a geometry | ``area:(1.0 .. 1E6)``  |
-    |                        | | having an area (measured in m²)  |                        |
-    |                        | | in the given range [2]_          |                        |
-    +------------------------+------------------------------------+------------------------+
-    | ``length:(from..to)``  | | matches features with a geometry | ``length:( .. 100)``   |
-    |                        | | having a length (measured in m)  |                        |
-    |                        | | in the given range [2]_          |                        |
-    +------------------------+------------------------------------+------------------------+
+    +-------------------------+------------------------------------+------------------------+
+    |                         | **description**                    | **example**            |
+    +=========================+====================================+========================+
+    | ``key=value``           | | matches all entities which       | ``natural=tree``       |
+    |                         | | have this exact tag              |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``key=*``               | | matches all entities which have  | ``addr:housenumber=*`` |
+    |                         | | any tag with the given key       |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``key!=value``          | | matches all entities             | ``oneway!=yes``        |
+    |                         | | which do not have                |                        |
+    |                         | | this exact tag                   |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``key!=*``              | | matches all entities which do not| ``name!=*``            |
+    |                         | | have any tag with the given key  |                        |
+    |                         | |                                  |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``key in (value list)`` | | matches all entities which do    | ``highway in           |
+    |                         | | have any tag with the given key  | (residential,          |
+    |                         | | and one of the given values      | living_street)``       |
+    +-------------------------+------------------------------------+------------------------+
+    | ``type:osm-type``       | | matches all entities of the      | ``type:node``          |
+    |                         | | given osm type                   |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``id:osm-id``           | | matches all entities with the    | ``id:1234``            |
+    |                         | | given osm id [1]_                |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``id:osm-type/osm-id``  | | matches the entity with the given| ``id:node/1234``       |
+    |                         | | osm type and id                  |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``id:(id list)``        | | matches all entities with the    | ``id:(1, 42, 1234)``   |
+    |                         | | given osm ids [1]_               |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``id:(id list)``        | | matches all entities with the    | ``id:(node/1, way/3)`` |
+    |                         | | given osm types and ids          |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``id:(id range)``       | | matches all entities with an id  | ``id:(1 .. 9999)``     |
+    |                         | | matching the given id range [2]_ |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``geometry:geom-type``  | | matches anything which has a     | ``geometry:polygon``   |
+    |                         | | geometry of the given type       |                        |
+    |                         | | (point, line, polygon, or other) |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``area:(from..to)``     | | matches features with a geometry | ``area:(1.0 .. 1E6)``  |
+    |                         | | having an area (measured in m²)  |                        |
+    |                         | | in the given range [2]_          |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``length:(from..to)``   | | matches features with a geometry | ``length:( .. 100)``   |
+    |                         | | having a length (measured in m)  |                        |
+    |                         | | in the given range [2]_          |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``changeset:id``        | | matches contributions [3]_       | ``changeset:42``       |
+    |                         | | performed in the specified       |                        |
+    |                         | | changeset                        |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``changeset:(id list)`` | | matches contributions [3]_       | ``changeset:(10, 42)`` |
+    |                         | | performed in one of the          |                        |
+    |                         | | specified changesets             |                        |
+    +-------------------------+------------------------------------+------------------------+
+    | ``changeset:(from..to)``| | matches contributions [3]_       | ``changeset:(10, 42)`` |
+    |                         | | performed in one of the          |                        |
+    |                         | | specified changesets             |                        |
+    +-------------------------+------------------------------------+------------------------+
 .. [1] Keep in mind that osm ids are not unique between osm types. In order to include only a specific object the id needs to be used together with an osm type filter. Alternatively, one can also use the combined type+id filter (e.g. `id:node/1234`).
 .. [2] The lower or upper bound of a range may be omitted to indicate that the values are only to be limited to be "up to" or "starting from" the given value, respectively. For example: `id:(10..)` will accept all entities with an id of 10 or higher.
+.. [3] The `changeset` filters can only be used in `contribution` based API endpoints.
 
 |
 

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -75,9 +75,9 @@ Selectors
     |                         | | performed in one of the          |                        |
     |                         | | specified changesets             |                        |
     +-------------------------+------------------------------------+------------------------+
-    | ``changeset:(from..to)``| | matches contributions [3]_       | ``changeset:(10, 42)`` |
-    |                         | | performed in one of the          |                        |
-    |                         | | specified changesets             |                        |
+    | ``changeset:(from..to)``| | matches contributions [3]_       | ``changeset:(10..42)`` |
+    |                         | | performed in a range of          |                        |
+    |                         | | changesets                       |                        |
     +-------------------------+------------------------------------+------------------------+
 .. [1] Keep in mind that osm ids are not unique between osm types. In order to include only a specific object the id needs to be used together with an osm type filter. Alternatively, one can also use the combined type+id filter (e.g. `id:node/1234`).
 .. [2] The lower or upper bound of a range may be omitted to indicate that the values are only to be limited to be "up to" or "starting from" the given value, respectively. For example: `id:(10..)` will accept all entities with an id of 10 or higher.


### PR DESCRIPTION
This add missing documentation about `changeset` [filters](https://github.com/GIScience/oshdb/tree/master/oshdb-filter) for contribution API endpoints.
