### PR TITLE
fix changed HTTP POST size property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ Changelog
 
 * fix bug which prevented error messages from being returned for non-unique parameters in POST requests ([#228])
 * fix a regression causing `…/groupBy/boundary` to crash when used with a geometry type filter using the (deprecated) types/keys/values parameter syntax ([#230])
+* fix changed name of property setting HTTP POST size ([#274])
 
 [#217]: https://github.com/GIScience/ohsome-api/issues/217
 [#224]: https://github.com/GIScience/ohsome-api/issues/224
 [#227]: https://github.com/GIScience/ohsome-api/issues/227
 [#228]: https://github.com/GIScience/ohsome-api/pull/228
 [#230]: https://github.com/GIScience/ohsome-api/pull/230
+[#274]: https://github.com/GIScience/ohsome-api/pull/274
 
 
 ## 1.6.3

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,8 @@ server.compression.min-response-size=1400
 server.compression.mime-types=application/json,text/csv,application/geo+json
 # Swagger documentation URL
 springfox.documentation.swagger.v2.path=/docs
-# Setting max size for post requests to 100MB (default: 2MB)
-server.tomcat.max-http-post-size=104857600
+# Setting max size for (formencoded) post requests to 100MB (default: 2MB)
+server.tomcat.max-http-form-post-size=104857600
 # Setting max file-size to 100MB (default: 10MB)
 spring.servlet.multipart.max-file-size=104857600
 # Setting max request-size to 100MB (default: 10MB)


### PR DESCRIPTION
### Description
fix changed HTTP POST size property name

### Corresponding issue
related to #272

### New or changed dependencies
None

### Checklist
- ~[ ] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~
- ~[ ] I have commented my code~
- ~[ ] I have written javadoc (required for public methods)~
- ~[ ] I have added sufficient unit and API tests~
- ~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~[ ] I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~