### PR TITLE
fix bug in …/groupBy/tag and …/groupBy/key endpoints when key/values do not exist in keytables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 ## 1.9.0-SNAPSHOT (current master)
 
+### Bug Fixes
+
+* Fix crash and incorrect output of `…/groupBy/tag` and `…/groupBy/key` endpoints when non-existing tag keys or values are used in a query ([#291])
+
+[#291]: https://github.com/GIScience/ohsome-api/pull/291
+
 
 ## 1.8.0
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/StringSimilarity.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/StringSimilarity.java
@@ -2,7 +2,6 @@ package org.heigit.ohsome.ohsomeapi.inputprocessing;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.text.similarity.FuzzyScore;

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/oshdb/DbConnData.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/oshdb/DbConnData.java
@@ -2,7 +2,6 @@ package org.heigit.ohsome.ohsomeapi.oshdb;
 
 import javax.sql.DataSource;
 import org.heigit.ohsome.oshdb.api.db.OSHDBDatabase;
-import org.heigit.ohsome.oshdb.api.db.OSHDBJdbc;
 import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
 
 /** Holds the database connection objects. */

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/utils/ConfigureApplication.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/utils/ConfigureApplication.java
@@ -99,7 +99,8 @@ public class ConfigureApplication {
   }
 
   /**
-   * Method run by the Application class to parse incoming command line arguments
+   * Method run by the Application class to parse incoming command line arguments.
+   *
    * @param args ApplicationArguments from spring to be parsed.
    */
   public static void parseArguments(ApplicationArguments args)

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/utils/FilterUtil.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/utils/FilterUtil.java
@@ -4,12 +4,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 
+/**
+ * Utility functions for OSHDB filters.
+ */
 public class FilterUtil {
   private FilterUtil() {}
 
+  /**
+   * Creates an OSHDB filter which selects OSM objects by their type.
+   *
+   * @param types the set of allowed OSM types
+   * @return a string representing an OSHDB filter matching the given set of OSM types
+   */
   public static String filter(Set<OSMType> types) {
     return types.stream()
       .map(type -> "type:" + type.toString().toLowerCase())
-      .collect(Collectors.joining(" or ", "( "," )"));
+      .collect(Collectors.joining(" or ", "( ", " )"));
   }
 }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/utils/RequestUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/utils/RequestUtils.java
@@ -4,13 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import org.heigit.ohsome.ohsomeapi.exception.DatabaseAccessException;
-import org.heigit.ohsome.ohsomeapi.exception.ExceptionMessages;
 import org.heigit.ohsome.ohsomeapi.inputprocessing.GeometryBuilder;
 import org.heigit.ohsome.ohsomeapi.inputprocessing.ProcessingData;
 import org.heigit.ohsome.ohsomeapi.oshdb.DbConnData;
 import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
 import org.heigit.ohsome.oshdb.api.db.OSHDBDatabase;
-import org.heigit.ohsome.oshdb.api.db.OSHDBJdbc;
 
 /** Utils class containing request-specific static utility methods. */
 public class RequestUtils {

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,9 +1,0 @@
-{
-  "properties": [
-    {
-      "name": "project.version",
-      "type": "java.lang.String",
-      "description": "Description for project.version."
-    }
-  ]
-}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "project.version",
+      "type": "java.lang.String",
+      "description": "Description for project.version."
+    }
+  ]
+}

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -92,7 +92,7 @@ public class DataExtractionTest {
     assertTrue("GeometryCollection"
         .equals(response.getBody().get("features").get(0).get("geometry").get("type").asText()));
   }
-  
+
   @Test
   public void elementsGeomUsingNoTagsTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/GetControllerTest.java
@@ -184,7 +184,8 @@ public class GetControllerTest {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
         + "/elements/count/groupBy/boundary/groupBy/tag?bboxes=8.68086,49.39948,8.69401,49.40609&"
-        + "time=2016-11-09&groupByKey=building&groupByValues=xxx,yyy,zzz&filter=type:way and building=*",
+        + "time=2016-11-09&groupByKey=building&groupByValues=xxx,yyy,zzz&"
+        + "filter=type:way and building=*",
         JsonNode.class);
     assertEquals(
         Set.of("building=xxx", "building=yyy", "building=zzz", "remainder"),
@@ -289,6 +290,23 @@ public class GetControllerTest {
                 response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
             .filter(jsonNode -> jsonNode.get("groupByObject").asText().equalsIgnoreCase("building"))
             .findFirst().get().get("result").get(0).get("value").asInt());
+  }
+
+  @Test
+  public void getElementsCountGroupByKeyUnknownKeysTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response =
+        restTemplate.getForEntity(
+            server + port + "/elements/count/groupBy/key?bboxes=8.67859,49.41189,8.67964,49.41263&"
+                + "time=2012-01-01&groupByKeys=DoesNotExist1,DoesNotExist2,DoesNotExist3&"
+                + "filter=type:way and building=*",
+            JsonNode.class);
+    assertEquals(
+        Set.of("DoesNotExist1", "DoesNotExist2", "DoesNotExist3", "remainder"),
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
+            .map(jsonNode -> jsonNode.get("groupByObject").asText())
+            .collect(Collectors.toSet()));
   }
 
   @Test
@@ -655,6 +673,24 @@ public class GetControllerTest {
   }
 
   @Test
+  public void getUsersCountGroupByKeyUnknownKeysTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response =
+        restTemplate.getForEntity(
+            server + port + "/users/count/groupBy/key?bboxes=8.67859,49.41189,8.67964,49.41263&"
+                + "time=2014-01-01,2015-01-01&"
+                + "groupByKeys=DoesNotExist1,DoesNotExist2,DoesNotExist3&"
+                + "filter=type:way and building=*",
+            JsonNode.class);
+    assertEquals(
+        Set.of("DoesNotExist1", "DoesNotExist2", "DoesNotExist3", "remainder", "total"),
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
+            .map(jsonNode -> jsonNode.get("groupByObject").asText())
+            .collect(Collectors.toSet()));
+  }
+
+  @Test
   public void getUsersCountGroupByTagTest() {
     TestRestTemplate restTemplate = new TestRestTemplate();
     ResponseEntity<JsonNode> response = restTemplate.getForEntity(
@@ -666,6 +702,41 @@ public class GetControllerTest {
             response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
         .filter(jsonNode -> jsonNode.get("groupByObject").asText().equalsIgnoreCase("building=yes"))
         .findFirst().get().get("result").get(0).get("value").asInt());
+  }
+
+  @Test
+  public void getUsersCountGroupByTagUnknownValuesTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response =
+        restTemplate.getForEntity(
+            server + port + "/users/count/groupBy/tag?bboxes=8.67859,49.41189,8.67964,49.41263&"
+                + "time=2014-01-01,2015-01-01&groupByKey=building&"
+                + "groupByValues=DoesNotExist1,DoesNotExist2&"
+                + "filter=type:way and building=*",
+            JsonNode.class);
+    assertEquals(
+        Set.of("building=DoesNotExist1", "building=DoesNotExist2", "remainder", "total"),
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
+            .map(jsonNode -> jsonNode.get("groupByObject").asText())
+            .collect(Collectors.toSet()));
+  }
+
+  @Test
+  public void getUsersCountGroupByTagUnknownKeyTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response =
+        restTemplate.getForEntity(
+            server + port + "/users/count/groupBy/tag?bboxes=8.67859,49.41189,8.67964,49.41263&"
+                + "time=2014-01-01,2015-01-01&groupByKey=DoesNotExist&groupByValues=xxx&"
+                + "filter=type:way and building=*",
+            JsonNode.class);
+    assertEquals(
+        Set.of("DoesNotExist=xxx", "remainder", "total"),
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                response.getBody().get("groupByResult").iterator(), Spliterator.ORDERED), false)
+            .map(jsonNode -> jsonNode.get("groupByObject").asText())
+            .collect(Collectors.toSet()));
   }
 
   @Test

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutorTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/executor/ContributionsExecutorTest.java
@@ -4,6 +4,7 @@ package org.heigit.ohsome.ohsomeapi.executor;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -45,7 +46,8 @@ public class ContributionsExecutorTest {
 
   @Test
   public void contributionsFilterInvalid() {
-    assertThrows(BadRequestException.class, () -> ExecutionUtils.contributionsFilter("doesnotexist"));
+    assertThrows(BadRequestException.class, () ->
+        ExecutionUtils.contributionsFilter("doesnotexist"));
 
   }
 

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/GeometryBuilderTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/GeometryBuilderTest.java
@@ -124,7 +124,8 @@ public class GeometryBuilderTest {
             + "{\"id\":\"Neuenheim\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[[[8.68465,"
             + "49.41769]]]}}]}";
     InputProcessor inputProcessor = new InputProcessor(processingData);
-    assertThrows(BadRequestException.class, () -> geomBuilder.createGeometryFromGeoJson(geoJson, inputProcessor));
+    assertThrows(BadRequestException.class, () ->
+        geomBuilder.createGeometryFromGeoJson(geoJson, inputProcessor));
   }
 
   @Test
@@ -136,14 +137,16 @@ public class GeometryBuilderTest {
             + "[8.2933214,49.4329125],[8.2936734,49.4330121],[8.2940745,49.4331354],"
             + "[8.2950478,49.4317345],[8.2944706,49.4313443]]]]}]}";
     InputProcessor inputProcessor = new InputProcessor(processingData);
-    assertThrows(BadRequestException.class, () -> geomBuilder.createGeometryFromGeoJson(geoJson, inputProcessor));
+    assertThrows(BadRequestException.class, () ->
+        geomBuilder.createGeometryFromGeoJson(geoJson, inputProcessor));
   }
 
   @Test
   public void createGeometryFromInvalidInputGeoJson() {
     String geoJson = "{\"type\": \"FeatureCollection\"}";
     InputProcessor inputProcessor = new InputProcessor(processingData);
-    assertThrows(BadRequestException.class, () -> geomBuilder.createGeometryFromGeoJson(geoJson, inputProcessor));
+    assertThrows(BadRequestException.class, () ->
+        geomBuilder.createGeometryFromGeoJson(geoJson, inputProcessor));
   }
 
   @Test
@@ -194,6 +197,7 @@ public class GeometryBuilderTest {
   @Test
   public void createGeometryFromWrongMetadataGeoJson() {
     String geoJson = "{\"type\":\"Polygon\",\"coordinates\":[Invalid-Input]}";
-    assertThrows(RuntimeException.class, () ->geomBuilder.createGeometryFromMetadataGeoJson(geoJson));
+    assertThrows(RuntimeException.class, () ->
+        geomBuilder.createGeometryFromMetadataGeoJson(geoJson));
   }
 }


### PR DESCRIPTION
Fixes a bug/crash in `…/groupBy/tag` requests triggered when using non-existing `groupByKey` or `groupByValues` are used in a query.

### To Reproduce

```
curl -X GET "https://api.ohsome.org/v1/elements/count/groupBy/tag?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type%3Away%20and%20building%3D*&format=json&groupByKey=building&groupByValues=DoesNotExist1&time=2023-01-01" -H  "accept: application/json"
```

This query is requesting results grouped by the tag `building` and value `DoesNotExist1` (which does not exits in the keytables). The result, however contains `building=yes` as the `groupByObject`. When performing a query with two non-existing `groupByValues` (e.g. `DoesNotExist1,DoesNotExist2`), the results includes two entries with `remainder` as `groupByObject`. When requesting three or more non-existing `groupByValues`, the query crashes and a 500 server error is returned.

Similar bugs occur when performing a query with a non-existing tag key as the `groupByKey`.

### The Problem and Fix

The issue is caused by a mistake in the code, where consecutive negative tag numbers are used as `keyInt`/`valuesInt` for OSM tags which do not exist in the keytables, but the hardcoded value `-1` is also used to represent the `remainder` portion of the result. This is causing the mixup between the value `DoesNotExist1` and the superfluous `remainder` entry in the example result above. Further, the negative pseudo-indices started at 0 which is also the index of the most common tag value for the corresponding tag. This is causing the mixup between the value `DoesNotExist2` and the result entry for the value `yes` in the example above. The crashes for any additional non-existing values are caused by a null pointer exception where the (still) non-existing pseudo-indices are attempted to be converted back to strings using the tag translator.

This is fixed by starting the negative pseudo-indices at position -2 where confusion with the -1 value for the `remainder` entry is possible and using the input values to resolve the pseudo-indices back to strings.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
