### PR TITLE
fix error message when changeset filter is used in snapshot query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## 1.9.0-SNAPSHOT (current master)
 
+### Bug Fixes
+* Show proper error message when a `changeset` filter is used on a snapshot based endpoint ([#289])
+
+[#289] https://github.com/GIScience/ohsome-api/issues/289
+
 
 ## 1.8.1
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/exception/ExceptionMessages.java
@@ -29,6 +29,9 @@ public class ExceptionMessages {
       + "when you set the filter parameter.";
   public static final String FILTER_SYNTAX = "Invalid filter syntax. Please look at the additional "
       + "info and examples about the filter parameter at https://docs.ohsome.org/ohsome-api.";
+  public static final String FILTER_INVALID_CHANGESET = "Invalid filter: The changeset filters can "
+      + "only be used in contribution based API endpoints. Please look at the additional "
+      + "info and examples about the filter parameter at https://docs.ohsome.org/ohsome-api.";
   public static final String GROUP_BY_KEY_PARAM =
       "You need to give one groupByKey parameter, if you want to use groupBy/tag.";
   public static final String GROUP_BY_KEYS_PARAM =

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -681,6 +681,10 @@ public class ElementsRequestExecutor {
     FilterParser fp = new FilterParser(DbConnData.tagTranslator);
     FilterExpression filterExpr1 = inputProcessor.getUtils().parseFilter(fp, filter1);
     FilterExpression filterExpr2 = inputProcessor.getUtils().parseFilter(fp, filter2);
+    if (!(InputProcessingUtils.filterSuitableForSnapshots(filterExpr1)
+        && InputProcessingUtils.filterSuitableForSnapshots(filterExpr2))) {
+      throw new BadRequestException(ExceptionMessages.FILTER_INVALID_CHANGESET);
+    }
     RequestParameters requestParamsCombined = new RequestParameters(servletRequest.getMethod(),
         isSnapshot, isDensity, servletRequest.getParameter("bboxes"),
         servletRequest.getParameter("bcircles"), servletRequest.getParameter("bpolys"),
@@ -985,6 +989,10 @@ public class ElementsRequestExecutor {
     final FilterParser fp = new FilterParser(DbConnData.tagTranslator);
     final FilterExpression filterExpr1 = inputProcessor.getUtils().parseFilter(fp, filter1);
     final FilterExpression filterExpr2 = inputProcessor.getUtils().parseFilter(fp, filter2);
+    if (!(InputProcessingUtils.filterSuitableForSnapshots(filterExpr1)
+        && InputProcessingUtils.filterSuitableForSnapshots(filterExpr2))) {
+      throw new BadRequestException(ExceptionMessages.FILTER_INVALID_CHANGESET);
+    }
     RequestParameters requestParamsCombined = new RequestParameters(servletRequest.getMethod(),
         isSnapshot, isDensity, servletRequest.getParameter("bboxes"),
         servletRequest.getParameter("bcircles"), servletRequest.getParameter("bpolys"),

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtils.java
@@ -5,6 +5,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -16,6 +17,9 @@ import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
 import org.heigit.ohsome.ohsomeapi.utils.TimestampFormatter;
 import org.heigit.ohsome.oshdb.OSHDBTag;
 import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
+import org.heigit.ohsome.oshdb.filter.ChangesetIdFilterEquals;
+import org.heigit.ohsome.oshdb.filter.ChangesetIdFilterEqualsAnyOf;
+import org.heigit.ohsome.oshdb.filter.ChangesetIdFilterRange;
 import org.heigit.ohsome.oshdb.filter.Filter;
 import org.heigit.ohsome.oshdb.filter.FilterExpression;
 import org.heigit.ohsome.oshdb.filter.FilterParser;
@@ -394,6 +398,19 @@ public class InputProcessingUtils implements Serializable {
       throw new BadRequestException(ExceptionMessages.FILTER_SYNTAX + " Detailed error message: "
           + ex.getMessage().replace("\n", " "));
     }
+  }
+
+  /**
+   * Returns whether a given filter is suitable for snapshots based endpoints.
+   *
+   * <p>For example, `changeset:*` filter can only be used on contribution based endpoints,
+   * see also <a href="https://github.com/GIScience/ohsome-api/issues/289">#289</a>.</p>
+   */
+  public static boolean filterSuitableForSnapshots(FilterExpression filter) {
+    return filter.normalize().stream().flatMap(Collection::stream)
+        .noneMatch(f -> f instanceof ChangesetIdFilterEquals
+                     || f instanceof ChangesetIdFilterRange
+                     || f instanceof ChangesetIdFilterEqualsAnyOf);
   }
 
   /**

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -245,6 +245,9 @@ public class InputProcessor {
         // call translator and add filters to mapRed
         FilterParser fp = new FilterParser(DbConnData.tagTranslator);
         FilterExpression filterExpr = utils.parseFilter(fp, filter);
+        if (isSnapshot && !InputProcessingUtils.filterSuitableForSnapshots(filterExpr)) {
+          throw new BadRequestException(ExceptionMessages.FILTER_INVALID_CHANGESET);
+        }
         processingData.setFilterExpression(filterExpr);
         if (!(processingData.isRatio()
             || processingData.isGroupByBoundary()

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/DummyTagTranslator.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/DummyTagTranslator.java
@@ -1,0 +1,56 @@
+package org.heigit.ohsome.ohsomeapi.inputprocessing;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.heigit.ohsome.oshdb.OSHDBRole;
+import org.heigit.ohsome.oshdb.OSHDBTag;
+import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
+import org.heigit.ohsome.oshdb.util.tagtranslator.OSMRole;
+import org.heigit.ohsome.oshdb.util.tagtranslator.OSMTag;
+import org.heigit.ohsome.oshdb.util.tagtranslator.OSMTagKey;
+import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
+
+public class DummyTagTranslator implements TagTranslator {
+
+  @Override
+  public Optional<OSHDBTagKey> getOSHDBTagKeyOf(OSMTagKey osmTagKey) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<OSHDBTag> getOSHDBTagOf(OSMTag osmTag) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Map<OSMTag, OSHDBTag> getOSHDBTagOf(Collection<OSMTag> collection) {
+    return null;
+  }
+
+  @Override
+  public Optional<OSHDBRole> getOSHDBRoleOf(OSMRole osmRole) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Map<OSMRole, OSHDBRole> getOSHDBRoleOf(Collection<OSMRole> collection) {
+    return null;
+  }
+
+  @Override
+  public OSMTag lookupTag(OSHDBTag oshdbTag) {
+    return null;
+  }
+
+  @Override
+  public Map<OSHDBTag, OSMTag> lookupTag(Set<? extends OSHDBTag> set) {
+    return null;
+  }
+
+  @Override
+  public OSMRole lookupRole(OSHDBRole oshdbRole) {
+    return null;
+  }
+}

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtilsTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtilsTest.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.ohsomeapi.inputprocessing;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -7,6 +8,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.heigit.ohsome.ohsomeapi.controller.TestProperties;
 import org.heigit.ohsome.ohsomeapi.exception.BadRequestException;
 import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
+import org.heigit.ohsome.oshdb.filter.FilterParser;
+import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,5 +113,15 @@ public class InputProcessingUtilsTest {
     assertTrue(timeVals[0].equals("2015-01-01T00:00:00Z"));
     assertTrue(timeVals[1].equals("2017-01-01T00:00:00Z"));
     assertTrue(timeVals[2].equals("P1Y"));
+  }
+
+  @SuppressWarnings("DataFlowIssue")
+  @Test void filterSuitableForSnapshots() {
+    TagTranslator dummyTagTranslator = new DummyTagTranslator();
+    FilterParser filterParser = new FilterParser(dummyTagTranslator);
+    assertTrue(InputProcessingUtils.filterSuitableForSnapshots(inProUtils.parseFilter(filterParser,
+        "type:node and id:42")));
+    assertFalse(InputProcessingUtils.filterSuitableForSnapshots(inProUtils.parseFilter(filterParser,
+        "type:node and changeset:42")));
   }
 }


### PR DESCRIPTION
### Description

Adds a check whether one of the `changeset:*` filters is used in a query and returns a proper error message if there is one, but the endpoint is based on the OSM entity _snapshots_.

before:

```
$ curl "https://api.ohsome.org/v1/elements/count?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type:way%20and%20changeset:55639048&format=json&time=2022-01-01"
{
  "timestamp" : "2023-02-22T13:12:44.754+00:00",
  "status" : 500,
  "error" : "Internal Server Error",
  "path" : "/elements/count"
}
```

after:

```
$ curl "http://localhost:8082/elements/count?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type:way%20and%20changeset:55639048&format=json&time=2018-01-01"
{
  "timestamp" : "2023-02-22T14:13:09.064943",
  "status" : 400,
  "message" : "Invalid filter: The changeset filters can only be used in contribution based API endpoints. Please look at the additional info and examples about the filter parameter at https://docs.ohsome.org/ohsome-api.",
  "requestUrl" : "http://localhost:8082/elements/count?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type:way%20and%20changeset:55639048&format=json&time=2018-01-01"
}
```

still works with contribution (and user) endpoints:

```
$ curl "http://localhost:8082/contributions/count?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type:way%20and%20changeset:55639048&format=json&time=2009-01-01,2019-01-01"
{
  "attribution" : {
    "url" : "https://ohsome.org/copyrights",
    "text" : "© OpenStreetMap contributors"
  },
  "apiVersion" : "1.9.0-SNAPSHOT",
  "result" : [ {
    "fromTimestamp" : "2009-01-01T00:00:00Z",
    "toTimestamp" : "2019-01-01T00:00:00Z",
    "value" : 23.0
  } ]
}
```

### Corresponding issue
Closes #289


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
