### PR TITLE
allow ContributionView-only filters in contribution extraction endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 Changelog
 =========
 
+## 1.10.0-SNAPSHOT (current master)
+
+### Bug Fixes
+* Fix bug which prevented some filters (which only work on ContributionView-based queries) to correctly work in contribution extraction endpoints ([#305])
+
+[#305]: https://github.com/GIScience/ohsome-api/issues/305
+
+
 ## 1.9.1
+
 * Upgrade OSHDB to version 1.1.2 [#302]
 
 [#302]: https://github.com/GIScience/ohsome-api/issues/302

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -460,6 +460,20 @@ public class DataExtractionTest {
     assertEquals("14227603", feature.get("properties").get("@contributionChangesetId").asText());
   }
 
+  @Test
+  public void contributionsChangesetFilterTest() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/contributions/bbox?bboxes=8.67,49.39,8.71,49.42&clipGeometry=true&"
+        + "filter=id:way/25316163 and changeset:14227603&"
+        + "properties=metadata,contributionTypes&time=2012-12-10,2017-12-11",
+        JsonNode.class);
+    var features = response.getBody().get("features");
+    assertEquals(1, features.size());
+    assertEquals("14227603",
+        features.get(0).get("properties").get("@contributionChangesetId").asText());
+  }
+
   /*
    * ./contributions/latest tests
    */


### PR DESCRIPTION
fixes #305 

The problem was that the code used the same method for both the full history data extraction and the "simple" contribution extraction endpoints. While the full history data extraction does in fact not work with contributions-only filters, the code prematurely exited even for the pure contribution extraction use case. This is now fixed by moving the full-history extraction specific code to where it does not interfere with the contribution extraction code path.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
