### PR TITLE
Fix bug: whitespaces are removed from tag values of groupByValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 ## 1.11.0-SNAPSHOT (current master)
 
+### Bug Fixes
+* Fix spaces from being removed from parameters like `groupByValues` ([#305])
+
+[#313]: https://github.com/GIScience/ohsome-api/issues/313
+
+
 ## 1.10.1
 
 * Fix performance degradation in previous release (version 1.10.0) which made data extractions very slow for medium to large query areas ([oshdb#516])

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java
@@ -325,11 +325,11 @@ public class InputProcessor {
    * Returns a String array containing the splits.
    *
    * @param param <code>String</code> array containing the content to split
-   * @return <code>String</code> array containing the splitted parameter content
+   * @return <code>String</code> array containing the split parameter content
    */
   public String[] splitParamOnComma(String[] param) {
     if (param.length == 1 && param[0].contains(",")) {
-      return param[0].replaceAll("\\s", "").split(",");
+      return Arrays.stream(param[0].split(",")).map(String::trim).toArray(String[]::new);
     }
     return param;
   }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtilsTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtilsTest.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.ohsomeapi.inputprocessing;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,6 +13,7 @@ import org.heigit.ohsome.oshdb.filter.FilterParser;
 import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 
@@ -123,5 +125,48 @@ public class InputProcessingUtilsTest {
         "type:node and id:42")));
     assertFalse(InputProcessingUtils.filterSuitableForSnapshots(inProUtils.parseFilter(filterParser,
         "type:node and changeset:42")));
+  }
+
+  // splitParamOnComma
+  @Nested
+  class SplitParamOnCommaTest {
+    InputProcessor dummyInputProcessor = new InputProcessor(null);
+
+    @Test
+    public void splitsString() {
+      var in = new String[]{ "A,B" };
+      var out = dummyInputProcessor.splitParamOnComma(in);
+      assertEquals(2, out.length);
+      assertEquals("A", out[0]);
+      assertEquals("B", out[1]);
+    }
+
+    @Test
+    public void preservesExistingList() {
+      var in = new String[]{ "A", "B", "C" };
+      var out = dummyInputProcessor.splitParamOnComma(in);
+      assertEquals(3, out.length);
+      assertEquals("A", out[0]);
+      assertEquals("B", out[1]);
+      assertEquals("C", out[2]);
+    }
+
+    @Test
+    public void trimsWhitespace() {
+      var in = new String[]{ "A , B" };
+      var out = dummyInputProcessor.splitParamOnComma(in);
+      assertEquals(2, out.length);
+      assertEquals("A", out[0]);
+      assertEquals("B", out[1]);
+    }
+
+    @Test
+    public void preservesSpacesInString() {
+      var in = new String[]{ "A B,C" };
+      var out = dummyInputProcessor.splitParamOnComma(in);
+      assertEquals(2, out.length);
+      assertEquals("A B", out[0]);
+      assertEquals("C", out[1]);
+    }
   }
 }


### PR DESCRIPTION
Fixes #313

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~
