### PR TITLE
fix timestamp format in ratio/groupBy/boundary endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 ## 1.11.0-SNAPSHOT (current master)
 
+### Bug Fixes
+* Fix inconsistent timestamp format in `/elements/(aggregation)/ratio/groupBy/boundary` request responses ([#318])
+
+[#318]: https://github.com/GIScience/ohsome-api/issues/318
+
+
 ## 1.10.1
 
 * Fix performance degradation in previous release (version 1.10.0) which made data extractions very slow for medium to large query areas ([oshdb#516])

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -923,9 +923,10 @@ public class ElementsRequestExecutor {
           resultValues2[matchesBothCount] = resultValues2[matchesBothCount]
               + Double.parseDouble(df.format(innerEntry.getValue().doubleValue()));
           if (!timeArrayFilled) {
-            String time = innerEntry.getKey().getFirstIndex().toString();
+            String time = TimestampFormatter.getInstance().isoDateTime(
+                innerEntry.getKey().getFirstIndex());
             if (matchesBothCount == 0 || !timeArray[timeArrayCount - 1].equals(time)) {
-              timeArray[timeArrayCount] = innerEntry.getKey().getFirstIndex().toString();
+              timeArray[timeArrayCount] = time;
               timeArrayCount++;
             }
           }
@@ -1083,9 +1084,10 @@ public class ElementsRequestExecutor {
           resultValues2[matchesBothCount] = resultValues2[matchesBothCount]
               + Double.parseDouble(df.format(innerEntry.getValue().doubleValue()));
           if (!timeArrayFilled) {
-            String time = innerEntry.getKey().getFirstIndex().toString();
+            String time = TimestampFormatter.getInstance().isoDateTime(
+                innerEntry.getKey().getFirstIndex());
             if (matchesBothCount == 0 || !timeArray[timeArrayCount - 1].equals(time)) {
-              timeArray[timeArrayCount] = innerEntry.getKey().getFirstIndex().toString();
+              timeArray[timeArrayCount] = time;
               timeArrayCount++;
             }
           }

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/PostControllerTest.java
@@ -742,6 +742,8 @@ public class PostControllerTest {
         server + port + "/elements/area/ratio/groupBy/boundary", map, JsonNode.class);
     assertEquals(expectedValue, response.getBody().get("groupByBoundaryResult").get(1)
         .get("ratioResult").get(0).get("ratio").asDouble(), expectedValue * deltaPercentage);
+    assertEquals("2017-01-01T00:00:00Z", response.getBody().get("groupByBoundaryResult").get(1)
+        .get("ratioResult").get(0).get("timestamp").asText());
   }
 
   @Test


### PR DESCRIPTION
Fixes inconsistency in timestamp format: All endpoints return timestamps in ISO format including the `Z` suffix to indicate the UTC timezone. Closes #318


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/master/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/master/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/master/CONTRIBUTING.md#check-examples).~~