### PR TITLE
fix contributions extraction endpoints for non-final deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ Changelog
 
 ## 1.11.0-SNAPSHOT (current main)
 
+### Bug Fixes
+* Fix contributions extractions endpoints which were missing _deletion_ contributions that were later reverted ([#324])
+
 ### Other
 * Fix filter documentation ([#326])
 
+[#324]: https://github.com/GIScience/ohsome-api/pull/324
 [#326]: https://github.com/GIScience/ohsome-api/pull/326
 
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -147,7 +147,8 @@ public class DataExtractionTransformer implements Serializable {
       properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, contribution.getChangesetId());
       output.add(exeUtils.createOSMFeature(entityAfter, geometryAfter, properties, keysInt,
           includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
-          outputGeometry, contribution.getContributionTypes()));
+          outputGeometry, contribution::getContributionTypes,
+          contribution.is(ContributionType.DELETION)));
     }
 
     return output;
@@ -185,7 +186,8 @@ public class DataExtractionTransformer implements Serializable {
           properties.put(VALID_TO_PROPERTY, validTo);
           output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
               includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
-              outputGeometry, contribution.getContributionTypes()));
+              outputGeometry, contribution::getContributionTypes,
+              contribution.is(ContributionType.DELETION)));
         }
       }
       skipNext = false;
@@ -215,7 +217,8 @@ public class DataExtractionTransformer implements Serializable {
         if (addToOutput) {
           output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
               includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
-              outputGeometry, lastContribution.getContributionTypes()));
+              outputGeometry, lastContribution::getContributionTypes,
+              lastContribution.is(ContributionType.DELETION)));
         }
       }
     }
@@ -251,7 +254,8 @@ public class DataExtractionTransformer implements Serializable {
     if (addToOutput) {
       return Collections.singletonList(exeUtils.createOSMFeature(entity, geom, properties,
           keysInt, includeTags, includeOSMMetadata, includeContributionTypes,
-          isContributionsEndpoint, outputGeometry, EnumSet.noneOf(ContributionType.class)));
+          isContributionsEndpoint, outputGeometry,
+          () -> EnumSet.noneOf(ContributionType.class), false));
     } else {
       return Collections.emptyList();
     }

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import org.heigit.ohsome.ohsomeapi.controller.dataextraction.elements.ElementsGeometry;
-import org.heigit.ohsome.ohsomeapi.inputprocessing.GeometryBuilder;
 import org.heigit.ohsome.ohsomeapi.inputprocessing.InputProcessingUtils;
 import org.heigit.ohsome.ohsomeapi.inputprocessing.SimpleFeatureType;
 import org.heigit.ohsome.ohsomeapi.utils.TimestampFormatter;
@@ -18,12 +17,9 @@ import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
 import org.wololo.geojson.Feature;
-import org.wololo.geojson.Point;
 
 /**
  * Used by data extraction requests to create GeoJSON features from OSM entities.

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/DataExtractionTransformer.java
@@ -113,6 +113,39 @@ public class DataExtractionTransformer implements Serializable {
    * @return list of GeoJSON features corresponding to the given OSM entity's modifications.
    */
   public List<Feature> buildChangedFeatures(List<OSMContribution> contributions) {
+    if (isContributionsEndpoint) {
+      return buildChangedFeaturesContributions(contributions);
+    } else {
+      return buildChangedFeaturesFullHistory(contributions);
+    }
+  }
+
+  private List<Feature> buildChangedFeaturesContributions(List<OSMContribution> contributions) {
+    List<Feature> output = new LinkedList<>();
+
+    for (int i = 0; i < contributions.size(); i++) {
+      if (isContributionsLatestEndpoint && i < contributions.size() - 1) {
+        // skip to end the loop when using contributions/latest endpoint
+        continue;
+      }
+      var contribution = contributions.get(i);
+      var currentEntity = contribution.getEntityAfter();
+      var currentGeom = ExecutionUtils.getGeometry(contribution, clipGeometries, false);
+      var timestamp = TimestampFormatter.getInstance().isoDateTime(contribution.getTimestamp());
+
+      Map<String, Object> properties = new TreeMap<>();
+
+      properties.put(TIMESTAMP_PROPERTY, timestamp);
+      properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, contribution.getChangesetId());
+      output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
+          includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
+          outputGeometry, contribution.getContributionTypes()));
+    }
+
+    return output;
+  }
+
+  private List<Feature> buildChangedFeaturesFullHistory(List<OSMContribution> contributions) {
     List<Feature> output = new LinkedList<>();
     Map<String, Object> properties;
     Geometry currentGeom = null;
@@ -120,59 +153,45 @@ public class DataExtractionTransformer implements Serializable {
     String validFrom = null;
     String validTo;
     boolean skipNext = false;
-    if (!isContributionsLatestEndpoint) {
-      // first contribution:
-      OSMContribution firstContribution = contributions.get(0);
-      if (firstContribution.is(ContributionType.CREATION) && !isContributionsEndpoint) {
+
+    // first contribution:
+    OSMContribution firstContribution = contributions.get(0);
+    if (firstContribution.is(ContributionType.CREATION)) {
+      skipNext = true;
+    } else {
+      // if not "creation": take "before" as starting "row" (geom, tags), valid_from = t_start
+      currentEntity = firstContribution.getEntityBefore();
+      currentGeom = ExecutionUtils.getGeometry(firstContribution, clipGeometries, true);
+      validFrom = startTimestamp;
+    }
+
+    // then for each contribution:
+    for (OSMContribution contribution : contributions) {
+      // set valid_to of previous row
+      validTo = TimestampFormatter.getInstance().isoDateTime(contribution.getTimestamp());
+      if (!skipNext && currentGeom != null && !currentGeom.isEmpty()) {
+        boolean addToOutput = addEntityToOutput(currentEntity, currentGeom);
+        if (addToOutput) {
+          properties = new TreeMap<>();
+          properties.put(VALID_FROM_PROPERTY, validFrom);
+          properties.put(VALID_TO_PROPERTY, validTo);
+          output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
+              includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
+              outputGeometry, contribution.getContributionTypes()));
+        }
+      }
+      skipNext = false;
+      if (contribution.is(ContributionType.DELETION)) {
+        // if deletion: skip output of next row
         skipNext = true;
       } else {
-        // if not "creation": take "before" as starting "row" (geom, tags), valid_from = t_start
-        currentEntity = firstContribution.getEntityBefore();
-        currentGeom = ExecutionUtils.getGeometry(firstContribution, clipGeometries, true);
-        validFrom = startTimestamp;
-      }
-      // then for each contribution:
-      for (int i = 0; i < contributions.size(); i++) {
-        if (i == contributions.size() - 1 && isContributionsEndpoint) {
-          // end the loop when last contribution is reached as it gets added later on
-          break;
-        }
-        OSMContribution contribution = contributions.get(i);
-        if (isContributionsEndpoint) {
-          currentEntity = contribution.getEntityAfter();
-          currentGeom = ExecutionUtils.getGeometry(contribution, clipGeometries, false);
-          validFrom = TimestampFormatter.getInstance().isoDateTime(contribution.getTimestamp());
-        }
-        // set valid_to of previous row
-        validTo = TimestampFormatter.getInstance().isoDateTime(contribution.getTimestamp());
-        if (!skipNext && currentGeom != null && !currentGeom.isEmpty()) {
-          boolean addToOutput = addEntityToOutput(currentEntity, currentGeom);
-          if (addToOutput) {
-            properties = new TreeMap<>();
-            if (!isContributionsEndpoint) {
-              properties.put(VALID_FROM_PROPERTY, validFrom);
-              properties.put(VALID_TO_PROPERTY, validTo);
-            } else {
-              properties.put(TIMESTAMP_PROPERTY, validTo);
-              properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, contribution.getChangesetId());
-            }
-            output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt,
-                includeTags, includeOSMMetadata, includeContributionTypes, isContributionsEndpoint,
-                outputGeometry, contribution.getContributionTypes()));
-          }
-        }
-        skipNext = false;
-        if (contribution.is(ContributionType.DELETION)) {
-          // if deletion: skip output of next row
-          skipNext = true;
-        } else if (!isContributionsEndpoint) {
-          // else: take "after" as next row
-          currentEntity = contribution.getEntityAfter();
-          currentGeom = ExecutionUtils.getGeometry(contribution, clipGeometries, false);
-          validFrom = TimestampFormatter.getInstance().isoDateTime(contribution.getTimestamp());
-        }
+        // else: take "after" as next row
+        currentEntity = contribution.getEntityAfter();
+        currentGeom = ExecutionUtils.getGeometry(contribution, clipGeometries, false);
+        validFrom = TimestampFormatter.getInstance().isoDateTime(contribution.getTimestamp());
       }
     }
+
     // after loop:
     OSMContribution lastContribution = contributions.get(contributions.size() - 1);
     currentGeom = ExecutionUtils.getGeometry(lastContribution, clipGeometries, false);
@@ -181,14 +200,8 @@ public class DataExtractionTransformer implements Serializable {
       // if last contribution was not "deletion": set valid_to = t_end
       validTo = endTimestamp;
       properties = new TreeMap<>();
-      if (!isContributionsEndpoint) {
-        properties.put(VALID_FROM_PROPERTY, validFrom);
-        properties.put(VALID_TO_PROPERTY, validTo);
-      } else {
-        properties.put(TIMESTAMP_PROPERTY,
-            TimestampFormatter.getInstance().isoDateTime(lastContribution.getTimestamp()));
-        properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, lastContribution.getChangesetId());
-      }
+      properties.put(VALID_FROM_PROPERTY, validFrom);
+      properties.put(VALID_TO_PROPERTY, validTo);
       if (!currentGeom.isEmpty()) {
         boolean addToOutput = addEntityToOutput(currentEntity, currentGeom);
         if (addToOutput) {
@@ -197,17 +210,8 @@ public class DataExtractionTransformer implements Serializable {
               outputGeometry, lastContribution.getContributionTypes()));
         }
       }
-    } else if (isContributionsEndpoint) {
-      // adds the deletion feature for a /contributions request
-      currentGeom = ExecutionUtils.getGeometry(lastContribution, clipGeometries, true);
-      properties = new TreeMap<>();
-      properties.put(TIMESTAMP_PROPERTY,
-          TimestampFormatter.getInstance().isoDateTime(lastContribution.getTimestamp()));
-      properties.put(CONTRIBUTION_CHANGESET_ID_PROPERTY, lastContribution.getChangesetId());
-      output.add(exeUtils.createOSMFeature(currentEntity, currentGeom, properties, keysInt, false,
-          includeOSMMetadata, includeContributionTypes, isContributionsEndpoint, outputGeometry,
-          lastContribution.getContributionTypes()));
     }
+
     return output;
   }
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/executor/ElementsRequestExecutor.java
@@ -130,7 +130,7 @@ public class ElementsRequestExecutor {
       }
       return exeUtils.createOSMFeature(snapshot.getEntity(), geom, properties, keysInt, includeTags,
           includeOSMMetadata, false, false, elemGeom,
-          EnumSet.noneOf(ContributionType.class));
+          () -> EnumSet.noneOf(ContributionType.class), false);
     }).filter(Objects::nonNull);
     Metadata metadata = null;
     if (processingData.isShowMetadata()) {

--- a/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
+++ b/src/test/java/org/heigit/ohsome/ohsomeapi/controller/DataExtractionTest.java
@@ -1,6 +1,8 @@
 package org.heigit.ohsome.ohsomeapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -472,6 +474,38 @@ public class DataExtractionTest {
     assertEquals(1, features.size());
     assertEquals("14227603",
         features.get(0).get("properties").get("@contributionChangesetId").asText());
+  }
+
+  @Test
+  public void contributionsDeletedEntity() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+            + "/contributions/bbox?bboxes=8.67,49.39,8.72,49.42"
+            + "&filter=type:node and id:1639495193&time=2012-01-01,2019-01-01&properties=metadata&clipGeometry=false",
+        JsonNode.class);
+    var features = response.getBody().get("features");
+    assertEquals(2, features.size());
+    assertEquals(1, features.get(0).get("properties").get("@version").asInt());
+    assertFalse(features.get(0).get("geometry").isNull());
+    assertEquals(2, features.get(1).get("properties").get("@version").asInt());
+    assertTrue(features.get(1).get("geometry").isNull());
+  }
+
+  @Test
+  public void contributionsUndeletedEntity() {
+    TestRestTemplate restTemplate = new TestRestTemplate();
+    ResponseEntity<JsonNode> response = restTemplate.getForEntity(server + port
+        + "/contributions/bbox?bboxes=8.67,49.39,8.72,49.42"
+        + "&filter=type:node and id:3451640407&time=2015-01-01,2016-01-01&properties=metadata&clipGeometry=false",
+        JsonNode.class);
+    var features = response.getBody().get("features");
+    assertEquals(3, features.size());
+    assertEquals(1, features.get(0).get("properties").get("@version").asInt());
+    assertFalse(features.get(0).get("geometry").isNull());
+    assertEquals(2, features.get(1).get("properties").get("@version").asInt());
+    assertTrue(features.get(1).get("geometry").isNull());
+    assertEquals(3, features.get(2).get("properties").get("@version").asInt());
+    assertFalse(features.get(2).get("geometry").isNull());
   }
 
   /*


### PR DESCRIPTION
This is the case when a deletion happens which was reverted later on. These "deletion" contributions are currently missing in the output of `/contributions` extraction endpoints.

For example `curl -X GET "https://api.ohsome.org/v1/contributions/geometry?bboxes=-180%2C-90%2C180%2C90&clipGeometry=true&filter=type%3Anode%20and%20id%3A1&properties=tags%2CcontributionTypes&time=2009-01-01%2C2012-01-01" -H  "accept: application/json"`, for [`node/1`](https://www.openstreetmap.org/node/1/history) one gets:

```json
  …
  }, {
    "type" : "Feature",
    "geometry" : {
      "type" : "Point",
      "coordinates" : [
        2.0,
        2.0
      ]
    },
    "properties" : {
      "@contributionChangesetId" : 524633,
      "@geometryChange" : true,
      "@osmId" : "node/1",
      "@tagChange" : true,
      "@timestamp" : "2009-04-14T15:42:57Z"
    }
  }, {
    "type" : "Feature",
    "geometry" : {
      "type" : "Point",
      "coordinates" : [
        9.4317166,
        51.2492152
      ]
    },
    "properties" : {
      "@contributionChangesetId" : 9035746,
      "@geometryChange" : true,
      "@osmId" : "node/1",
      "@timestamp" : "2011-08-16T11:26:47Z"
    }
  }, {
  …
```

Note that there is no contribution on `2009-07-07T22:44:41Z`, corresponding to [version 4](https://www.openstreetmap.org/api/0.6/node/1/4) of the node. This would be the expected result:

```json
  …
  }, {
    "type" : "Feature",
    "geometry" : {
      "type" : "Point",
      "coordinates" : [
        2.0,
        2.0
      ]
    },
    "properties" : {
      "@contributionChangesetId" : 524633,
      "@geometryChange" : true,
      "@osmId" : "node/1",
      "@tagChange" : true,
      "@timestamp" : "2009-04-14T15:42:57Z"
    }
  }, {
    "type" : "Feature",
    "geometry" : null,
    "properties" : {
      "@contributionChangesetId" : 1767082,
      "@deletion" : true,
      "@osmId" : "node/1",
      "@timestamp" : "2009-07-07T22:44:41Z"
    }
  }, {
    "type" : "Feature",
    "geometry" : {
      "type" : "Point",
      "coordinates" : [
        9.4317166,
        51.2492152
      ]
    },
    "properties" : {
      "@contributionChangesetId" : 9035746,
      "@geometryChange" : true,
      "@osmId" : "node/1",
      "@timestamp" : "2011-08-16T11:26:47Z"
    }
  }, {
  …
```


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit and API tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/main/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/main/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#check-examples).~~
