### PR TITLE
fix crash caused by overly complex filters, fixes #330

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## 1.11.0-SNAPSHOT (current main)
+
+### Bug Fixes
+* Fix crash in non-contribution based endpoints caused by very long and complex filters ([#330])
+
+[#330]: https://github.com/GIScience/ohsome-api/issues/330
+
+
 ## 1.10.3
 
 ### Bug Fixes

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtils.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessingUtils.java
@@ -5,7 +5,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -17,6 +16,7 @@ import org.heigit.ohsome.ohsomeapi.oshdb.ExtractMetadata;
 import org.heigit.ohsome.ohsomeapi.utils.TimestampFormatter;
 import org.heigit.ohsome.oshdb.OSHDBTag;
 import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
+import org.heigit.ohsome.oshdb.filter.BinaryOperator;
 import org.heigit.ohsome.oshdb.filter.ChangesetIdFilterEquals;
 import org.heigit.ohsome.oshdb.filter.ChangesetIdFilterEqualsAnyOf;
 import org.heigit.ohsome.oshdb.filter.ChangesetIdFilterRange;
@@ -407,10 +407,16 @@ public class InputProcessingUtils implements Serializable {
    * see also <a href="https://github.com/GIScience/ohsome-api/issues/289">#289</a>.</p>
    */
   public static boolean filterSuitableForSnapshots(FilterExpression filter) {
-    return filter.normalize().stream().flatMap(Collection::stream)
-        .noneMatch(f -> f instanceof ChangesetIdFilterEquals
-                     || f instanceof ChangesetIdFilterRange
-                     || f instanceof ChangesetIdFilterEqualsAnyOf);
+    if (filter instanceof ChangesetIdFilterEquals
+        || filter instanceof ChangesetIdFilterRange
+        || filter instanceof ChangesetIdFilterEqualsAnyOf) {
+      return false;
+    }
+    if (filter instanceof BinaryOperator operator) {
+      return filterSuitableForSnapshots(operator.getLeftOperand())
+          && filterSuitableForSnapshots(operator.getRightOperand());
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
instead of iterating through the normalized filter, this checks for the presence of non-snapshot compatible filters by recursively searching through the filter tree.

Fixes #330


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- ~~[ ] I have written javadoc (required for public methods)~~
- ~~[ ] I have added sufficient unit and API tests~~
- ~~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/main/docs)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/main/CHANGELOG.md)
- ~~[ ] I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#check-examples).~~
