### PR TITLE
add /filter/validate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## 1.11.0-SNAPSHOT (current main)
 
+### New Features
+* add new endpoint `/filter/validate` that checks a given ohsome filter string for syntax errors.
 
 ## 1.10.4
 

--- a/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/filter/ValidateController.java
+++ b/src/main/lombok/org/heigit/ohsome/ohsomeapi/controller/filter/ValidateController.java
@@ -1,0 +1,53 @@
+package org.heigit.ohsome.ohsomeapi.controller.filter;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.heigit.ohsome.ohsomeapi.exception.BadRequestException;
+import org.heigit.ohsome.ohsomeapi.exception.ExceptionMessages;
+import org.heigit.ohsome.ohsomeapi.oshdb.DbConnData;
+import org.heigit.ohsome.oshdb.filter.FilterExpression;
+import org.heigit.ohsome.oshdb.filter.FilterParser;
+import org.jparsec.error.ParserException;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for endpoints in "/filter".
+ */
+@Api(tags = "Filter")
+@RestController
+@RequestMapping("/filter")
+public class ValidateController {
+  /**
+   * Validates a provided filter string: Returns 200 OK if the syntax is valid
+   * and an HTTP 400 error code otherwise.
+   *
+   * @param servletRequest <code>HttpServletRequest</code> of the incoming request
+   * @param servletResponse <code>HttpServletResponse</code> of the outgoing response
+   * @throws BadRequestException if a te filter cannot be parsed, the error object contains a
+   *         message about the potential causes of the invalidity of the filter.
+   * @return if the filter is valid: the originally supplied filter
+   */
+  @ApiOperation(nickname = "Filter Validator", value = "Checks a given ohsome filter string for syntax errors.")
+  @RequestMapping(value = "/validate", method = {RequestMethod.GET, RequestMethod.POST},
+      produces = {"text/plain", "application/json"})
+  public String validate(HttpServletRequest servletRequest,
+      HttpServletResponse servletResponse) {
+    FilterParser fp = new FilterParser(DbConnData.tagTranslator, true);
+    String filter = servletRequest.getParameter("filter");
+    if (filter == null || filter.isEmpty()) {
+      throw new BadRequestException("No filter parameter provided.");
+    }
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      fp.parse(filter);
+      return filter;
+    } catch (ParserException ex) {
+      throw new BadRequestException(ExceptionMessages.FILTER_SYNTAX + " Detailed error message: "
+          + ex.getMessage().replace("\n", " "));
+    }
+  }
+}


### PR DESCRIPTION
### Description

Adds a new endpoint `/filter/validate` which tests a provided [ohsome filter](https://docs.ohsome.org/ohsome-api/v1/filter.html) string for syntax correctness.

Examples:

```
Request: GET http://127.0.0.1:8083/filter/validate?filter=foo=bar
Response: HTTP 200, body: foo=bar

Request: GET http://127.0.0.1:8083/filter/validate
Response: HTTP 400, body: {…, "status": 400, message: "No filter parameter provided.", … }

Request: GET http://127.0.0.1:8083/filter/validate?filter=type:
Response: HTTP 400, body: {…, "status": 400, message: "Invalid filter syntax. … Detailed error message: line1, column 6: … expected, EOF encountered.", … }

Request: POST http://127.0.0.1:8083/filter/validate, body: filter=foo%3Dbar%26bar
Response: HTTP 200, body: foo=bar

Request: POST http://127.0.0.1:8083/filter/validate, body: <empty>
Response: HTTP 400, body: {…, "status": 400, message: "No filter parameter provided.", … }

Request: POST http://127.0.0.1:8083/filter/validate, body: filter=filter=type%3A
Response: HTTP 400, body: {…, "status": 400, message: "Invalid filter syntax. … Detailed error message: line1, column 6: … expected, EOF encountered.", … }
```

This endpoint is currently considered "experimental" and therefore not listed in the documentation or the swagger ui.


### Checklist
- [ ] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- ~~I have added sufficient unit and API tests~~
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/main/docs)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/main/CHANGELOG.md)
- ~~I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#check-examples).~~

