### PR TITLE
fix(docs): add missing dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,6 @@ sphinx-copybutton
 
 # workaround because of https://github.com/miyakogi/m2r/issues/66
 mistune<2.0.0
+
+# workaround because sphinxcontrib-openapi is missing setuptools --2025-03-07
+setuptools


### PR DESCRIPTION
### Description
Adds missing sphinx dependency.

### Corresponding issue
None

### New or changed dependencies
- `setuptools` (for docs)

### Checklist
~- [ ] My code follows the [code-style](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#code-style) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/ohsome-api/view/change-requests/)~
- [x] I have commented my code
~- [ ] I have written javadoc (required for public methods)~
~- [ ] I have added sufficient unit and API tests~
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/ohsome-api/tree/main/docs)
~- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-api/blob/main/CHANGELOG.md)~
~- [ ] I have adjusted the examples in the [check-ohsome-api](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api) script or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/helpers/check-ohsome-api/-/issues/new) in the corresponding repository. More Information [here](https://github.com/GIScience/ohsome-api/blob/main/CONTRIBUTING.md#check-examples).~